### PR TITLE
cleanup: Add test sweepers to opsgenie user and team

### DIFF
--- a/opsgenie/sweeper_test.go
+++ b/opsgenie/sweeper_test.go
@@ -1,0 +1,30 @@
+package opsgenie
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sharedConfigForRegion(region string) (interface{}, error) {
+	if os.Getenv("OPSGENIE_API_KEY") == "" {
+		return nil, fmt.Errorf("OPSGENIE_API_KEY must be set")
+	}
+
+	config := Config{
+		ApiKey: os.Getenv("OPSGENIE_API_KEY"),
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return nil, fmt.Errorf("error getting OpsGenie client")
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
```
% go test ./opsgenie -v -sweep=op-east                                                                                                                                                                    ✹
2017/06/30 12:16:39 [DEBUG] Running Sweepers for region (op-east):
2017/06/30 12:16:39 [INFO] OpsGenie client configured
2017/06/30 12:16:40 Destroying team acctest1848944086017479799
2017/06/30 12:16:41 Destroying team acctest7933330709063528414
2017/06/30 12:16:42 [INFO] OpsGenie client configured
2017/06/30 12:16:43 Destroying user acctest-2492090423408064051@example.tld
2017/06/30 12:16:44 Sweeper Tests ran:
	- opsgenie_team
	- opsgenie_user
ok  	github.com/terraform-providers/terraform-provider-opsgenie/opsgenie	4.784s
```