### PR TITLE
Fixing the User Tests

### DIFF
--- a/opsgenie/import_opsgenie_team_test.go
+++ b/opsgenie/import_opsgenie_team_test.go
@@ -3,8 +3,6 @@ package opsgenie
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,7 +11,7 @@ func TestAccOpsGenieTeam_importBasic(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_basic, ri)
+	config := testAccOpsGenieTeam_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +35,7 @@ func TestAccOpsGenieTeam_importWithEmptyDescription(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withEmptyDescription, ri)
+	config := testAccOpsGenieTeam_withEmptyDescription(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,7 +59,7 @@ func TestAccOpsGenieTeam_importWithUser(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withUser, ri, ri)
+	config := testAccOpsGenieTeam_withUser(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,7 +83,7 @@ func TestAccOpsGenieTeam_importWithUserComplete(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withUserComplete, ri, ri)
+	config := testAccOpsGenieTeam_withUserComplete(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/opsgenie/import_opsgenie_team_test.go
+++ b/opsgenie/import_opsgenie_team_test.go
@@ -10,8 +10,8 @@ import (
 func TestAccOpsGenieTeam_importBasic(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_basic(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_basic(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,8 @@ func TestAccOpsGenieTeam_importBasic(t *testing.T) {
 func TestAccOpsGenieTeam_importWithEmptyDescription(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withEmptyDescription(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withEmptyDescription(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -58,8 +58,8 @@ func TestAccOpsGenieTeam_importWithEmptyDescription(t *testing.T) {
 func TestAccOpsGenieTeam_importWithUser(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withUser(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withUser(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,8 +82,8 @@ func TestAccOpsGenieTeam_importWithUser(t *testing.T) {
 func TestAccOpsGenieTeam_importWithUserComplete(t *testing.T) {
 	resourceName := "opsgenie_team.test"
 
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withUserComplete(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withUserComplete(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/opsgenie/import_opsgenie_user_test.go
+++ b/opsgenie/import_opsgenie_user_test.go
@@ -10,8 +10,8 @@ import (
 func TestAccOpsGenieUser_importBasic(t *testing.T) {
 	resourceName := "opsgenie_user.test"
 
-	ri := acctest.RandInt()
-	config := testAccOpsGenieUser_basic(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieUser_basic(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,8 @@ func TestAccOpsGenieUser_importBasic(t *testing.T) {
 func TestAccOpsGenieUser_importComplete(t *testing.T) {
 	resourceName := "opsgenie_user.test"
 
-	ri := acctest.RandInt()
-	config := testAccOpsGenieUser_complete(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieUser_complete(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/opsgenie/import_opsgenie_user_test.go
+++ b/opsgenie/import_opsgenie_user_test.go
@@ -3,8 +3,6 @@ package opsgenie
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,7 +11,7 @@ func TestAccOpsGenieUser_importBasic(t *testing.T) {
 	resourceName := "opsgenie_user.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieUser_basic, ri)
+	config := testAccOpsGenieUser_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +35,7 @@ func TestAccOpsGenieUser_importComplete(t *testing.T) {
 	resourceName := "opsgenie_user.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieUser_complete, ri)
+	config := testAccOpsGenieUser_complete(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/opsgenie/resource_opsgenie_team_test.go
+++ b/opsgenie/resource_opsgenie_team_test.go
@@ -128,7 +128,7 @@ func TestAccOpsGenieTeamRole_validation(t *testing.T) {
 
 func TestAccOpsGenieTeam_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_basic, ri)
+	config := testAccOpsGenieTeam_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,7 +147,7 @@ func TestAccOpsGenieTeam_basic(t *testing.T) {
 
 func TestAccOpsGenieTeam_withEmptyDescription(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withEmptyDescription, ri)
+	config := testAccOpsGenieTeam_withEmptyDescription(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -166,7 +166,7 @@ func TestAccOpsGenieTeam_withEmptyDescription(t *testing.T) {
 
 func TestAccOpsGenieTeam_withUser(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withUser, ri, ri)
+	config := testAccOpsGenieTeam_withUser(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -185,7 +185,7 @@ func TestAccOpsGenieTeam_withUser(t *testing.T) {
 
 func TestAccOpsGenieTeam_withUserComplete(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withUserComplete, ri, ri)
+	config := testAccOpsGenieTeam_withUserComplete(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -204,7 +204,7 @@ func TestAccOpsGenieTeam_withUserComplete(t *testing.T) {
 
 func TestAccOpsGenieTeam_withMultipleUsers(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieTeam_withMultipleUsers, ri, ri, ri)
+	config := testAccOpsGenieTeam_withMultipleUsers(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -268,20 +268,25 @@ func testCheckOpsGenieTeamExists(name string) resource.TestCheckFunc {
 	}
 }
 
-var testAccOpsGenieTeam_basic = `
+func testAccOpsGenieTeam_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_team" "test" {
   name = "acctest%d"
 }
-`
+`, rInt)
+}
 
-var testAccOpsGenieTeam_withEmptyDescription = `
+func testAccOpsGenieTeam_withEmptyDescription (rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_team" "test" {
   name        = "acctest%d"
   description = ""
 }
-`
+`, rInt)
+}
 
-var testAccOpsGenieTeam_withUser = `
+func testAccOpsGenieTeam_withUser(rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
   username  = "acctest-%d@example.tld"
   full_name = "Acceptance Test User"
@@ -294,9 +299,11 @@ resource "opsgenie_team" "test" {
     username = "${opsgenie_user.test.username}"
   }
 }
-`
+`, rInt, rInt)
+}
 
-var testAccOpsGenieTeam_withUserComplete = `
+func testAccOpsGenieTeam_withUserComplete(rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
   username  = "acctest-%d@example.tld"
   full_name = "Acceptance Test User"
@@ -310,10 +317,11 @@ resource "opsgenie_team" "test" {
     username = "${opsgenie_user.test.username}"
     role     = "user"
   }
+}`, rInt, rInt)
 }
-`
 
-var testAccOpsGenieTeam_withMultipleUsers = `
+func testAccOpsGenieTeam_withMultipleUsers(rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_user" "first" {
   username  = "acctest-1-%d@example.tld"
   full_name = "First Acceptance Test User"
@@ -335,4 +343,5 @@ resource "opsgenie_team" "test" {
     username = "${opsgenie_user.second.username}"
   }
 }
-`
+`, rInt, rInt, rInt)
+}

--- a/opsgenie/resource_opsgenie_team_test.go
+++ b/opsgenie/resource_opsgenie_team_test.go
@@ -127,8 +127,8 @@ func TestAccOpsGenieTeamRole_validation(t *testing.T) {
 }
 
 func TestAccOpsGenieTeam_basic(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_basic(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_basic(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -146,8 +146,8 @@ func TestAccOpsGenieTeam_basic(t *testing.T) {
 }
 
 func TestAccOpsGenieTeam_withEmptyDescription(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withEmptyDescription(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withEmptyDescription(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,8 +165,8 @@ func TestAccOpsGenieTeam_withEmptyDescription(t *testing.T) {
 }
 
 func TestAccOpsGenieTeam_withUser(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withUser(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withUser(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -184,8 +184,8 @@ func TestAccOpsGenieTeam_withUser(t *testing.T) {
 }
 
 func TestAccOpsGenieTeam_withUserComplete(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withUserComplete(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withUserComplete(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -203,8 +203,8 @@ func TestAccOpsGenieTeam_withUserComplete(t *testing.T) {
 }
 
 func TestAccOpsGenieTeam_withMultipleUsers(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieTeam_withMultipleUsers(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieTeam_withMultipleUsers(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -268,73 +268,73 @@ func testCheckOpsGenieTeamExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccOpsGenieTeam_basic(rInt int) string {
+func testAccOpsGenieTeam_basic(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_team" "test" {
-  name = "acctest%d"
+  name = "acctest%s"
 }
-`, rInt)
+`, rString)
 }
 
-func testAccOpsGenieTeam_withEmptyDescription (rInt int) string {
+func testAccOpsGenieTeam_withEmptyDescription(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_team" "test" {
-  name        = "acctest%d"
+  name        = "acctest%s"
   description = ""
 }
-`, rInt)
+`, rString)
 }
 
-func testAccOpsGenieTeam_withUser(rInt int) string {
+func testAccOpsGenieTeam_withUser(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
-  username  = "acctest-%d@example.tld"
+  username  = "terraform-acctest+%s@hashicorp.com"
   full_name = "Acceptance Test User"
   role      = "User"
 }
 
 resource "opsgenie_team" "test" {
-  name  = "acctest%d"
+  name  = "acctests%s"
   member {
     username = "${opsgenie_user.test.username}"
   }
 }
-`, rInt, rInt)
+`, rString, rString)
 }
 
-func testAccOpsGenieTeam_withUserComplete(rInt int) string {
+func testAccOpsGenieTeam_withUserComplete(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
-  username  = "acctest-%d@example.tld"
+  username  = "terraform-acctest+%s@hashicorp.com"
   full_name = "Acceptance Test User"
   role      = "User"
 }
 
 resource "opsgenie_team" "test" {
-  name        = "acctest%d"
+  name        = "acctest%s"
   description = "Some exmaple description"
   member {
     username = "${opsgenie_user.test.username}"
     role     = "user"
   }
-}`, rInt, rInt)
+}`, rString, rString)
 }
 
-func testAccOpsGenieTeam_withMultipleUsers(rInt int) string {
+func testAccOpsGenieTeam_withMultipleUsers(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_user" "first" {
-  username  = "acctest-1-%d@example.tld"
+  username  = "terraform-acctest+%s1@hashicorp.com"
   full_name = "First Acceptance Test User"
   role      = "User"
 }
 resource "opsgenie_user" "second" {
-  username  = "acctest-2-%d@example.tld"
+  username  = "terraform-acctest+%s2@hashicorp.com"
   full_name = "Second Acceptance Test User"
   role      = "User"
 }
 
 resource "opsgenie_team" "test" {
-  name        = "acctest%d"
+  name        = "acctest%s"
   description = "Some exmaple description"
   member {
     username = "${opsgenie_user.first.username}"
@@ -343,5 +343,5 @@ resource "opsgenie_team" "test" {
     username = "${opsgenie_user.second.username}"
   }
 }
-`, rInt, rInt, rInt)
+`, rString, rString, rString)
 }

--- a/opsgenie/resource_opsgenie_user_test.go
+++ b/opsgenie/resource_opsgenie_user_test.go
@@ -143,8 +143,8 @@ func TestAccOpsGenieUserRole_validation(t *testing.T) {
 }
 
 func TestAccOpsGenieUser_basic(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieUser_basic(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieUser_basic(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -162,8 +162,8 @@ func TestAccOpsGenieUser_basic(t *testing.T) {
 }
 
 func TestAccOpsGenieUser_complete(t *testing.T) {
-	ri := acctest.RandInt()
-	config := testAccOpsGenieUser_complete(ri)
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieUser_complete(rs)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -227,24 +227,24 @@ func testCheckOpsGenieUserExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccOpsGenieUser_basic(rInt int) string {
+func testAccOpsGenieUser_basic(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
-  username  = "acctest-%d@example.tld"
+  username  = "terraform-acctest+%s@hashicorp.com"
   full_name = "Acceptance Test User"
   role      = "User"
 }
-`, rInt)
+`, rString)
 }
 
-func testAccOpsGenieUser_complete(rInt int) string {
+func testAccOpsGenieUser_complete(rString string) string {
 	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
-  username  = "acctest-%d@example.tld"
+  username  = "terraform-acctest+%s@hashicorp.com"
   full_name = "Acceptance Test User"
   role      = "User"
   locale    = "en_GB"
   timezone  = "Etc/GMT"
 }
-`, rInt)
+`, rString)
 }

--- a/opsgenie/resource_opsgenie_user_test.go
+++ b/opsgenie/resource_opsgenie_user_test.go
@@ -144,7 +144,7 @@ func TestAccOpsGenieUserRole_validation(t *testing.T) {
 
 func TestAccOpsGenieUser_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieUser_basic, ri)
+	config := testAccOpsGenieUser_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -163,7 +163,7 @@ func TestAccOpsGenieUser_basic(t *testing.T) {
 
 func TestAccOpsGenieUser_complete(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccOpsGenieUser_complete, ri)
+	config := testAccOpsGenieUser_complete(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -227,15 +227,18 @@ func testCheckOpsGenieUserExists(name string) resource.TestCheckFunc {
 	}
 }
 
-var testAccOpsGenieUser_basic = `
+func testAccOpsGenieUser_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
   username  = "acctest-%d@example.tld"
   full_name = "Acceptance Test User"
   role      = "User"
 }
-`
+`, rInt)
+}
 
-var testAccOpsGenieUser_complete = `
+func testAccOpsGenieUser_complete(rInt int) string {
+	return fmt.Sprintf(`
 resource "opsgenie_user" "test" {
   username  = "acctest-%d@example.tld"
   full_name = "Acceptance Test User"
@@ -243,4 +246,5 @@ resource "opsgenie_user" "test" {
   locale    = "en_GB"
   timezone  = "Etc/GMT"
 }
-`
+`, rInt)
+}


### PR DESCRIPTION
Noticed that the OpsGenis tests were failing as OpsGenie are now validating for a proper TLD; as such I've updated this to use the `terraform-acctest+foo` email (I tried using `example.com` as a TLD, but the API complained about using disposable email addresses..)

Tests pass:

```
 $ acctests opsgenie TestAccOpsGenie
=== RUN   TestAccOpsGenieTeam_importBasic
--- PASS: TestAccOpsGenieTeam_importBasic (10.70s)
=== RUN   TestAccOpsGenieTeam_importWithEmptyDescription
--- PASS: TestAccOpsGenieTeam_importWithEmptyDescription (4.70s)
=== RUN   TestAccOpsGenieTeam_importWithUser
--- PASS: TestAccOpsGenieTeam_importWithUser (8.88s)
=== RUN   TestAccOpsGenieTeam_importWithUserComplete
--- PASS: TestAccOpsGenieTeam_importWithUserComplete (8.63s)
=== RUN   TestAccOpsGenieUser_importBasic
--- PASS: TestAccOpsGenieUser_importBasic (4.30s)
=== RUN   TestAccOpsGenieUser_importComplete
--- PASS: TestAccOpsGenieUser_importComplete (4.88s)
=== RUN   TestAccOpsGenieTeamName_validation
--- PASS: TestAccOpsGenieTeamName_validation (0.00s)
=== RUN   TestAccOpsGenieTeamRole_validation
--- PASS: TestAccOpsGenieTeamRole_validation (0.00s)
=== RUN   TestAccOpsGenieTeam_basic
--- PASS: TestAccOpsGenieTeam_basic (4.29s)
=== RUN   TestAccOpsGenieTeam_withEmptyDescription
--- PASS: TestAccOpsGenieTeam_withEmptyDescription (4.34s)
=== RUN   TestAccOpsGenieTeam_withUser
--- PASS: TestAccOpsGenieTeam_withUser (9.22s)
=== RUN   TestAccOpsGenieTeam_withUserComplete
--- PASS: TestAccOpsGenieTeam_withUserComplete (9.52s)
=== RUN   TestAccOpsGenieTeam_withMultipleUsers
--- PASS: TestAccOpsGenieTeam_withMultipleUsers (8.25s)
=== RUN   TestAccOpsGenieUserUsername_validation
--- PASS: TestAccOpsGenieUserUsername_validation (0.00s)
=== RUN   TestAccOpsGenieUserFullName_validation
--- PASS: TestAccOpsGenieUserFullName_validation (0.00s)
=== RUN   TestAccOpsGenieUserRole_validation
--- PASS: TestAccOpsGenieUserRole_validation (0.00s)
=== RUN   TestAccOpsGenieUser_basic
--- PASS: TestAccOpsGenieUser_basic (4.35s)
=== RUN   TestAccOpsGenieUser_complete
--- PASS: TestAccOpsGenieUser_complete (4.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opsgenie/opsgenie	86.372s
```