### PR TITLE
Add warning if Opsgenie username string containers uppercase characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.3.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* **Show warning if Opsgenie username (email addr) contains uppercase characters. This lead to unexpected behaviour in the past.**
+
 ## 0.2.8 (February 07, 2020)
 
 IMPROVEMENTS:

--- a/opsgenie/resource_opsgenie_user.go
+++ b/opsgenie/resource_opsgenie_user.go
@@ -3,6 +3,7 @@ package opsgenie
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/opsgenie/opsgenie-go-sdk-v2/user"
 
@@ -163,6 +164,10 @@ func validateOpsGenieUserUsername(v interface{}, k string) (ws []string, errors 
 
 	if len(value) >= 100 {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 100 characters: %q %d", k, value, len(value)))
+	}
+
+	if value != strings.ToLower(value) {
+		errors = append(errors, fmt.Errorf("%v contains uppercase characters, only lowercase characters are allowed: %q", k, value))
 	}
 
 	return

--- a/opsgenie/resource_opsgenie_user_test.go
+++ b/opsgenie/resource_opsgenie_user_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -91,6 +92,21 @@ func TestAccOpsGenieUser_complete(t *testing.T) {
 	})
 }
 
+func TestAccOpsGenieUser_usernameValidationError(t *testing.T) {
+	rs := acctest.RandString(6)
+	config := testAccOpsGenieUser_usernameValidationError(rs)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`config is invalid: username contains uppercase characters, only lowercase characters are allowed: "GenieTest-%v@opsgenie.com"`, rs)),
+			},
+		},
+	})
+}
+
 func testCheckOpsGenieUserDestroy(s *terraform.State) error {
 	client, err := user.NewClient(testAccProvider.Meta().(*OpsgenieClient).client.Config)
 	if err != nil {
@@ -163,6 +179,16 @@ resource "opsgenie_user" "test" {
   role      = "User"
   locale    = "en_GB"
   timezone = "Europe/Rome"
+}
+`, rString)
+}
+
+func testAccOpsGenieUser_usernameValidationError(rString string) string {
+	return fmt.Sprintf(`
+resource "opsgenie_user" "test" {
+  username  = "GenieTest-%s@opsgenie.com"
+  full_name = "Acceptance Test User"
+  role      = "User"
 }
 `, rString)
 }

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -26,7 +26,7 @@ resource "opsgenie_user" "test" {
 
 The following arguments are supported:
 
-* `username` - (Required) The email address associated with this user. Opsgenie defines that this must not be longer than 100 characters.
+* `username` - (Required) The email address associated with this user. Opsgenie defines that this must not be longer than 100 characters and must contain lowercase characters only.
 
 * `full_name` - (Required) The Full Name of the User.
 


### PR DESCRIPTION
If you supply an e-mail addrs containing uppercase characters..

* .. in the UI, OpsGenie will accept it but converts the string to lowercase before writing to database.
* .. currently in terraform you will get a mismatching local state<>Opsgenie, because Terraform won't be informed about the lowercase conversion.

This is not documented in the OpsGenie API but I think it's better to help the Terraform user to not make this mistake.

```
$  OPSGENIE_API_URL=api.eu.opsgenie.com OPSGENIE_API_KEY=42 TF_ACC=1 go test -v github.com/terraform-providers/terraform-provider-opsgenie/opsgenie -run TestAccOpsGenieUser_usernameValidationError
=== RUN   TestAccOpsGenieUser_usernameValidationError
--- PASS: TestAccOpsGenieUser_usernameValidationError (0.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-opsgenie/opsgenie	(cached)
```