### PR TITLE
Fix Team Routing Rule resource docs

### DIFF
--- a/website/docs/r/team_routing_rule.html.markdown
+++ b/website/docs/r/team_routing_rule.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a Team Routing Rule within Opsgenie.
 ---
 
-# opsgenie\_team
+# opsgenie\_team\_routing\_rule
 
 Manages a Team Routing Rule within Opsgenie.
 
@@ -117,7 +117,7 @@ The following attributes are exported:
 
 ## Import
 
-Teams can be imported using the `id`, e.g.
+Team Routing Rules can be imported using the `id`, e.g.
 
 `$ terraform import opsgenie_team_routing_rule.ruletest teamId/routingRuleId`
 


### PR DESCRIPTION
This PR will fix Team Routing Rule docs `h1` header and `Import` section description.