### PR TITLE
Fix make command in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-opsgenie
 ...


### PR DESCRIPTION
Replace `make bin` with `make build` in README.