### PR TITLE
Fix opsgenie_schedule_rotation resource import

### DIFF
--- a/opsgenie/resource_opsgenie_schedule_rotation_test.go
+++ b/opsgenie/resource_opsgenie_schedule_rotation_test.go
@@ -134,9 +134,7 @@ func testCheckOpsGenieScheduleRotationDestroy(s *terraform.State) error {
 				return errors.New(fmt.Sprintf("Schedule rotation still exists : %s", x.Error()))
 			}
 		}
-
 	}
-
 	return nil
 }
 
@@ -194,8 +192,8 @@ resource "opsgenie_schedule_rotation" "test" {
     schedule_id = "${opsgenie_schedule.test.id}"
     name = "test-%s"
     start_date = "2019-06-18T17:30:00Z"
-    end_date ="2019-06-20T17:30:00Z"
-    type ="hourly"
+    end_date = "2019-06-20T17:30:00Z"
+    type = "hourly"
     length = 6
     participant {
       type = "user"
@@ -203,14 +201,14 @@ resource "opsgenie_schedule_rotation" "test" {
     }
 
     time_restriction {
-      type ="time-of-day"
+      type = "time-of-day"
       restriction {
         start_hour = 1
-        start_min = 1
+        start_min = 0
         end_hour = 10
-        end_min = 1
+        end_min = 0
       }
-}
+    }
 }
 `, randomUser, randomTeam, randomSchedule, randomRotation)
 }
@@ -249,13 +247,13 @@ resource "opsgenie_schedule_rotation" "test" {
     }
 
     time_restriction {
-      	type ="time-of-day"
-      	restriction {
+      type ="time-of-day"
+      restriction {
         start_hour = 1
-        start_min = 1
+        start_min = 0
         end_hour = 10
-        end_min = 1
-		}
+        end_min = 0
+	  }
 	}
 }
 
@@ -275,11 +273,11 @@ resource "opsgenie_schedule_rotation" "test2" {
       type ="time-of-day"
       restriction {
         start_hour = 1
-        start_min = 1
+        start_min = 0
         end_hour = 10
-        end_min = 1
+        end_min = 0
       }
-}
+    }
 }
 `, randomName, randomTeam, randomSchedule, randomRotation, randomRotation2)
 }

--- a/opsgenie/resource_opsgenie_team_routing_rule.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule.go
@@ -3,9 +3,10 @@ package opsgenie
 import (
 	"context"
 	"fmt"
-	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"log"
 	"strings"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/team"
@@ -125,7 +126,7 @@ func resourceOpsGenieTeamRoutingRule() *schema.Resource {
 							Required: true,
 						},
 						"restrictions": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/website/docs/r/schedule_rotation.html.markdown
+++ b/website/docs/r/schedule_rotation.html.markdown
@@ -15,9 +15,9 @@ Manages a Schedule Rotation within Opsgenie.
 resource "opsgenie_schedule_rotation" "test" { 
   schedule_id = "${opsgenie_schedule.test.id}"
   name        = "test"
-  start_date  = "2019-06-18T17:45:00Z"
-  end_date    ="2019-06-20T17:45:00Z"
-  type        ="hourly"
+  start_date  = "2019-06-18T17:00:00Z"
+  end_date    = "2019-06-20T17:30:00Z"
+  type        = "hourly"
   length      = 6
   
   participant {
@@ -38,7 +38,6 @@ resource "opsgenie_schedule_rotation" "test" {
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -53,11 +52,11 @@ The following arguments are supported:
 
 * `type` - (Required) Type of rotation. May be one of daily, weekly and hourly.
 
-* `length` - (Required) Length of the rotation with default value 1.
+* `length` - (Optional) Length of the rotation with default value 1.
 
 * `participant` - (Required) List of escalations, teams, users or the reserved word none which will be used in schedule. Each of them can be used multiple times and will be rotated in the order they given. "user,escalation,team,none"
 
-* `time_restriction` - (Required)
+* `time_restriction` - (Optional)
 
 `participant` supports the following:
 
@@ -66,18 +65,29 @@ The following arguments are supported:
 
 `time_restriction` supports the following:
 
-* `type` - (Required) This parameter should be set time-of-day
+* `type` - (Required) This parameter should be set to `time-of-day` or `weekday-and-time-of-day`.
                       
-* `restriction` - (Required) It is a restriction object which is described below. In this case startDay/endDay fields are not supported.
+* `restriction` - (Optional) It is a restriction object which is described below. In this case startDay/endDay fields are not supported. This can be used only if time restriction type is `time-of-day`.
 
     `restriction` supports the following:
 
-     * `start_hour` - (Required) Value of the hour that frame will start
+     * `start_hour` - (Required) Value of the hour that frame will start.
      * `start_min` - (Required) Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
      * `end_hour` - (Required) Value of the hour that frame will end.
      * `end_min` - (Required) Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
 
+* `restrictions` - (Optional) It is a restriction object which is described below. This can be used only if time restriction type is `weekday-and-time-of-day`.
 
+    `restrictions` supports the following:
+
+     * `start_day` - (Required) Value of the day that frame will start.
+     * `start_hour` - (Required) Value of the hour that frame will start
+     * `start_min` - (Required) Value of the minute that frame will start. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+     * `end_day` - (Required) Value of the day that frame will end.
+     * `end_hour` - (Required) Value of the hour that frame will end.
+     * `end_min` - (Required) Value of the minute that frame will end. Minutes may take 0 or 30 as value. Otherwise they will be converted to nearest 0 or 30 automatically.
+
+     Both `start_day` and `end_day` can assume only `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, or `sunday` values.
 
 ## Attributes Reference
 


### PR DESCRIPTION
After importing existing `opsgenie_schedule_rotation` resources into terraform state, some attributes are missing and `terraform plan` shows that they have to be created even if they have been already configured.

This PR will fix this issue by introducing reading support for `time_restriction`, `length`, `name`, and `end_date` attributes .