### PR TITLE
Handle heartbeat not found error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- "1.12.x"
+- "1.14.x"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/opsgenie/integration_util.go
+++ b/opsgenie/integration_util.go
@@ -1,11 +1,14 @@
 package opsgenie
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/integration"
 )
 
@@ -64,3 +67,10 @@ const (
 	ApiIntegrationType   = "API"
 	EmailIntegrationType = "Email"
 )
+
+func isNotFoundError(err error) bool {
+	var apiError *client.ApiError
+	match := errors.As(err, &apiError)
+
+	return match && apiError.StatusCode == http.StatusNotFound
+}

--- a/opsgenie/resource_opsgenie_heartbeat.go
+++ b/opsgenie/resource_opsgenie_heartbeat.go
@@ -113,7 +113,7 @@ func resourceOpsgenieHeartbeatRead(d *schema.ResourceData, meta interface{}) err
 
 	result, err := client.Get(context.Background(), d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf("%w [id=%s]", err, d.Id())
 	}
 
 	d.Set("name", result.Name)

--- a/opsgenie/resource_opsgenie_heartbeat.go
+++ b/opsgenie/resource_opsgenie_heartbeat.go
@@ -3,10 +3,11 @@ package opsgenie
 import (
 	"context"
 	"fmt"
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/heartbeat"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
-	"regexp"
 )
 
 func resourceOpsgenieHeartbeat() *schema.Resource {
@@ -112,7 +113,10 @@ func resourceOpsgenieHeartbeatRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	result, err := client.Get(context.Background(), d.Id())
-	if err != nil {
+	if isNotFoundError(err) {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("%w [id=%s]", err, d.Id())
 	}
 


### PR DESCRIPTION
Towards: https://github.com/terraform-providers/terraform-provider-opsgenie/issues/103

When a heartbeat is in terraform.state but missing from the opsgenie api, terraform fails with a 404 error when trying to read this heartbeat instead of deleting it from its state.

This PR add handling for the 404 not found error in case a heartbeat is found missing.

```diff
$ terraform refresh
opsgenie_heartbeat.heartbeat["foo"]: Refreshing state... [id=foo]
opsgenie_heartbeat.heartbeat["bar"]: Refreshing state... [id=bar]
$ git diff terraform.state
diff --git a/terraform.tfstate b/terraform.tfstate
index efbb7b2..194948a 100644
--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -32,23 +32,6 @@
           },
           "private": "bnVsbA=="
         },
-        {
-          "index_key": "bar",
-          "schema_version": 0,
-          "attributes": {
-            "alert_message": "Heartbeat [bar] is expired.",
-            "alert_priority": "P3",
-            "alert_tags": [],
-            "enabled": true,
-            "id": "bar",
-            "interval": 25,
-            "interval_unit": "minutes",
-            "name": "bar",
-          },
-          "private": "bnVsbA=="
-        }
      ]
    }
  ]
```

This PR also wrap the error with the heartbeat id. Note the `[id=bar]` at the end of the error line.

```
$ terraform refresh
opsgenie_heartbeat.heartbeat["foo"]: Refreshing state... [id=foo]
opsgenie_heartbeat.heartbeat["bar"]: Refreshing state... [id=bar]

Error: Error occurred with Status code: 404, Message: Heartbeat not found, Took: 0.005000, RequestId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx [id=bar]
```