### PR TITLE
Re-create resources that have been deleted by hand

### DIFF
--- a/opsgenie/resource_opsgenie_api_integration.go
+++ b/opsgenie/resource_opsgenie_api_integration.go
@@ -12,7 +12,7 @@ import (
 func resourceOpsgenieApiIntegration() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieApiIntegrationCreate,
-		Read:   resourceOpsgenieApiIntegrationRead,
+		Read:   handleNonExistentResource(resourceOpsgenieApiIntegrationRead),
 		Update: resourceOpsgenieApiIntegrationUpdate,
 		Delete: resourceOpsgenieApiIntegrationDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_email_integration.go
+++ b/opsgenie/resource_opsgenie_email_integration.go
@@ -2,8 +2,9 @@ package opsgenie
 
 import (
 	"context"
-	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 	"log"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/integration"
@@ -12,7 +13,7 @@ import (
 func resourceOpsgenieEmailIntegration() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieEmailIntegrationCreate,
-		Read:   resourceOpsgenieEmailIntegrationRead,
+		Read:   handleNonExistentResource(resourceOpsgenieEmailIntegrationRead),
 		Update: resourceOpsgenieEmailIntegrationUpdate,
 		Delete: resourceOpsgenieEmailIntegrationDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_escalation.go
+++ b/opsgenie/resource_opsgenie_escalation.go
@@ -15,7 +15,7 @@ import (
 func resourceOpsgenieEscalation() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieEscalationCreate,
-		Read:   resourceOpsgenieEscalationRead,
+		Read:   handleNonExistentResource(resourceOpsgenieEscalationRead),
 		Update: resourceOpsgenieEscalationUpdate,
 		Delete: resourceOpsgenieEscalationDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_heartbeat.go
+++ b/opsgenie/resource_opsgenie_heartbeat.go
@@ -3,16 +3,17 @@ package opsgenie
 import (
 	"context"
 	"fmt"
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/heartbeat"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
-	"regexp"
 )
 
 func resourceOpsgenieHeartbeat() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieHeartbeatCreate,
-		Read:   resourceOpsgenieHeartbeatRead,
+		Read:   handleNonExistentResource(resourceOpsgenieHeartbeatRead),
 		Update: resourceOpsgenieHeartbeatUpdate,
 		Delete: resourceOpsgenieHeartbeatDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_maintenance.go
+++ b/opsgenie/resource_opsgenie_maintenance.go
@@ -14,7 +14,7 @@ import (
 func resourceOpsgenieMaintenance() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieMaintenanceCreate,
-		Read:   resourceOpsgenieMaintenanceRead,
+		Read:   handleNonExistentResource(resourceOpsgenieMaintenanceRead),
 		Update: resourceOpsgenieMaintenanceUpdate,
 		Delete: resourceOpsgenieMaintenanceDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_notification_policy.go
+++ b/opsgenie/resource_opsgenie_notification_policy.go
@@ -33,7 +33,7 @@ var (
 func resourceOpsGenieNotificationPolicy() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsGenieNotificationPolicyCreate,
-		Read:   resourceOpsGenieNotificationPolicyRead,
+		Read:   handleNonExistentResource(resourceOpsGenieNotificationPolicyRead),
 		Update: resourceOpsGenieNotificationPolicyUpdate,
 		Delete: resourceOpsGenieNotificationPolicyDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_schedule.go
+++ b/opsgenie/resource_opsgenie_schedule.go
@@ -17,7 +17,7 @@ import (
 func resourceOpsgenieSchedule() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieScheduleCreate,
-		Read:   resourceOpsgenieScheduleRead,
+		Read:   handleNonExistentResource(resourceOpsgenieScheduleRead),
 		Update: resourceOpsgenieScheduleUpdate,
 		Delete: resourceOpsgenieScheduleDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_schedule_rotation.go
+++ b/opsgenie/resource_opsgenie_schedule_rotation.go
@@ -16,7 +16,7 @@ import (
 func resourceOpsgenieScheduleRotation() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsgenieScheduleRotationCreate,
-		Read:   resourceOpsgenieScheduleRotationRead,
+		Read:   handleNonExistentResource(resourceOpsgenieScheduleRotationRead),
 		Update: resourceOpsgenieScheduleRotationUpdate,
 		Delete: resourceOpsgenieScheduleRotationDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -14,7 +14,7 @@ import (
 func resourceOpsGenieTeam() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsGenieTeamCreate,
-		Read:   resourceOpsGenieTeamRead,
+		Read:   handleNonExistentResource(resourceOpsGenieTeamRead),
 		Update: resourceOpsGenieTeamUpdate,
 		Delete: resourceOpsGenieTeamDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_team_routing_rule.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule.go
@@ -15,7 +15,7 @@ import (
 func resourceOpsGenieTeamRoutingRule() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsGenieTeamRoutingRuleCreate,
-		Read:   resourceOpsGenieTeamRoutingRuleRead,
+		Read:   handleNonExistentResource(resourceOpsGenieTeamRoutingRuleRead),
 		Update: resourceOpsGenieTeamRoutingRuleUpdate,
 		Delete: resourceOpsGenieTeamRoutingRuleDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_user.go
+++ b/opsgenie/resource_opsgenie_user.go
@@ -15,7 +15,7 @@ import (
 func resourceOpsGenieUser() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsGenieUserCreate,
-		Read:   resourceOpsGenieUserRead,
+		Read:   handleNonExistentResource(resourceOpsGenieUserRead),
 		Update: resourceOpsGenieUserUpdate,
 		Delete: resourceOpsGenieUserDelete,
 		Importer: &schema.ResourceImporter{

--- a/opsgenie/resource_opsgenie_user_contact.go
+++ b/opsgenie/resource_opsgenie_user_contact.go
@@ -13,7 +13,7 @@ import (
 func resourceOpsGenieUserContact() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceOpsGenieUserContactCreate,
-		Read:   resourceOpsGenieUserContactRead,
+		Read:   handleNonExistentResource(resourceOpsGenieUserContactRead),
 		Update: resourceOpsGenieUserContactUpdate,
 		Delete: resourceOpsGenieUserContactDelete,
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
# Description

Whenever the API returns a 404 during a read it means that the resource
was deleted by hand through the UI. The expected behaviour after this
happens is that the terraform provider should try to re-created the
resource that was deleted.
To implement this and touch the least amount of the code we added a
wrapper that receives a ReadFunc and handles the API error that we care
about.

This PR was implemented live on [The Wildcast](https://twitch.tv/thewildcast) with the great @marcosnils 🎉 

Closes #101

Signed-off-by: Matias Pan <matias.pan26@gmail.com>