### PR TITLE
opsgenie_api_integration: Preserve manually set fields by the user

### DIFF
--- a/opsgenie/resource_opsgenie_api_integration.go
+++ b/opsgenie/resource_opsgenie_api_integration.go
@@ -167,7 +167,7 @@ func resourceOpsgenieApiIntegrationUpdate(d *schema.ResourceData, meta interface
 	}
 
 	// GET+PUT workaround since the Opsgenie Integration API does not support HTTP PATCH method
-	var userProperties integration.OtherFields
+	userProperties := integration.OtherFields{}
 	result, err := client.Get(context.Background(), &integration.GetRequest{
 		Id: d.Id(),
 	})
@@ -176,6 +176,7 @@ func resourceOpsgenieApiIntegrationUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 	userProperties = result.Data
+	userProperties["allowWriteAccess"] = d.Get("allow_write_access")
 
 	name := d.Get("name").(string)
 	integrationType := d.Get("type").(string)

--- a/opsgenie/resource_opsgenie_api_integration.go
+++ b/opsgenie/resource_opsgenie_api_integration.go
@@ -165,6 +165,18 @@ func resourceOpsgenieApiIntegrationUpdate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
+	// GET+PUT workaround since the Opsgenie Integration API does not support HTTP PATCH method
+	var userProperties integration.OtherFields
+	result, err := client.Get(context.Background(), &integration.GetRequest{
+		Id: d.Id(),
+	})
+	if err != nil {
+		log.Printf("Error occurred while performing GET for integration: %s", d.Id())
+		return err
+	}
+	userProperties = result.Data
+
 	name := d.Get("name").(string)
 	integrationType := d.Get("type").(string)
 	ignoreRespondersFromPayload := d.Get("ignore_responders_from_payload").(bool)
@@ -183,6 +195,7 @@ func resourceOpsgenieApiIntegrationUpdate(d *schema.ResourceData, meta interface
 		SuppressNotifications:       &suppressNotifications,
 		Responders:                  expandOpsgenieIntegrationResponders(d),
 		Enabled:                     &enabled,
+		OtherFields:                 userProperties,
 	}
 
 	log.Printf("[INFO] Updating OpsGenie api based integration '%s'", name)


### PR DESCRIPTION
**Synopsis: opsgenie_api_integration: manually set fields get reset (#111)**

Issue: Upon applying terraform config with an updated integration resource, the provider was performing REST call with the core resource schema that was known to Terraform. This unset all other integration-specific properties that might have been set by the user via API or Web UI. The Integrations API supports only GET/PUT/DELETE as documented.

This PR adds logic to fetch all the fields in the integration properties and include them in the update HTTP PUT call (via OtherFields). Also, _readOnly fields are dropped since API will complain with HTTP 403 if they were being sent again.
