### PR TITLE
[TeamRoutingRule] Parse missing NOT field while flattening the criteria

### DIFF
--- a/opsgenie/resource_opsgenie_team_routing_rule.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule.go
@@ -203,13 +203,18 @@ func resourceOpsGenieTeamRoutingRuleCreate(d *schema.ResourceData, meta interfac
 	criteria := d.Get("criteria").([]interface{})
 	notify := d.Get("notify").([]interface{})
 
+	expandedCriteria := expandOpsgenieCriteria(criteria)
+	if err := validateOpsgenieCriteria(expandedCriteria); err != nil {
+		return err
+	}
+
 	createRequest := &team.CreateRoutingRuleRequest{
 		TeamIdentifierType:  team.Id,
 		TeamIdentifierValue: teamId,
 		Name:                name,
 		Order:               &order,
 		Timezone:            timezone,
-		Criteria:            expandOpsgenieCriteria(criteria),
+		Criteria:            expandedCriteria,
 		Notify:              expandOpsgenieNotify(notify),
 	}
 
@@ -266,13 +271,18 @@ func resourceOpsGenieTeamRoutingRuleUpdate(d *schema.ResourceData, meta interfac
 	criteria := d.Get("criteria").([]interface{})
 	notify := d.Get("notify").([]interface{})
 
+	expandedCriteria := expandOpsgenieCriteria(criteria)
+	if err := validateOpsgenieCriteria(expandedCriteria); err != nil {
+		return err
+	}
+
 	updateRequest := &team.UpdateRoutingRuleRequest{
 		TeamIdentifierType:  team.Id,
 		TeamIdentifierValue: teamId,
 		RoutingRuleId:       d.Id(),
 		Name:                name,
 		Timezone:            timezone,
-		Criteria:            expandOpsgenieCriteria(criteria),
+		Criteria:            expandedCriteria,
 		Notify:              expandOpsgenieNotify(notify),
 	}
 	if len(timeRestriction) > 0 {
@@ -395,6 +405,13 @@ func expandOpsgenieNotify(input []interface{}) *team.Notify {
 	}
 	return &notify
 
+}
+
+func validateOpsgenieCriteria(criteria *og.Criteria) error {
+	if criteria.CriteriaType == "match-all" && len(criteria.Conditions) > 0 {
+		return fmt.Errorf("criteria cannot have conditions set when type is match-all: %v", criteria)
+	}
+	return nil
 }
 
 func expandOpsgenieCriteria(input []interface{}) *og.Criteria {

--- a/opsgenie/resource_opsgenie_team_routing_rule.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule.go
@@ -3,6 +3,7 @@ package opsgenie
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 	"strings"
 
@@ -76,8 +77,9 @@ func resourceOpsGenieTeamRoutingRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"match-all", "match-any-condition", "match-all-conditions"}, false),
 						},
 
 						"conditions": {
@@ -273,7 +275,6 @@ func resourceOpsGenieTeamRoutingRuleUpdate(d *schema.ResourceData, meta interfac
 		Criteria:            expandOpsgenieCriteria(criteria),
 		Notify:              expandOpsgenieNotify(notify),
 	}
-
 	if len(timeRestriction) > 0 {
 		updateRequest.TimeRestriction = expandTimeRestrictions(timeRestriction)
 	}

--- a/opsgenie/resource_opsgenie_team_routing_rule.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule.go
@@ -333,6 +333,7 @@ func flattenOpsgenieCriteria(input og.Criteria) []map[string]interface{} {
 		conditionMap["expected_value"] = r.ExpectedValue
 		conditionMap["operation"] = r.Operation
 		conditionMap["field"] = r.Field
+		conditionMap["not"] = r.IsNot
 		conditions = append(conditions, conditionMap)
 	}
 	out["conditions"] = conditions

--- a/opsgenie/resource_opsgenie_team_routing_rule_test.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule_test.go
@@ -163,18 +163,18 @@ resource "opsgenie_team_routing_rule" "test" {
   order    = 0
   timezone = "America/Los_Angeles"
   criteria {
-    type = "match-all"
-    conditions {
-      field          = "message"
-      operation      = "contains"
-      expected_value = "expected1"
-      not            = false
-    }
+    type = "match-all-conditions"
     conditions {
       field          = "message"
       operation      = "contains"
       expected_value = "unexpected1"
       not            = true
+    }
+    conditions {
+      field          = "message"
+      operation      = "contains"
+      expected_value = "expected1"
+      not            = false
     }
   }
   time_restriction {

--- a/opsgenie/resource_opsgenie_team_routing_rule_test.go
+++ b/opsgenie/resource_opsgenie_team_routing_rule_test.go
@@ -163,12 +163,18 @@ resource "opsgenie_team_routing_rule" "test" {
   order    = 0
   timezone = "America/Los_Angeles"
   criteria {
-    type = "match-any-condition"
+    type = "match-all"
     conditions {
       field          = "message"
       operation      = "contains"
       expected_value = "expected1"
       not            = false
+    }
+    conditions {
+      field          = "message"
+      operation      = "contains"
+      expected_value = "unexpected1"
+      not            = true
     }
   }
   time_restriction {
@@ -186,7 +192,6 @@ resource "opsgenie_team_routing_rule" "test" {
     name = "${opsgenie_schedule.test.name}"
     type = "schedule"
   }
-
 }
 `, scheduleName, teamName, routingRuleName)
 }

--- a/website/docs/r/team_routing_rule.html.markdown
+++ b/website/docs/r/team_routing_rule.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 * `type` - (Required) Type of the operation will be applied on conditions. Should be one of match-all, match-any-condition or match-all-conditions.
 
-* `conditions` - (Optional) List of conditions will be checked before applying team routing rule.
+* `conditions` - (Optional) List of conditions will be checked before applying team routing rule. This field declaration should be omitted if the criteria type is set to match-all.
 
 
 `conditions` supports the following:


### PR DESCRIPTION
Changed:
* resource_opsgenie_team_routing_rule: flattenOpsgenieCriteria() conditionMap.not was not being populated from API and hence the expand function was accessing default value always (false)
* Validate criteria.type to match one of valid strings
* During resource create/update, validate the schema to assert that criteria.conditions is empty when criteria.type is match-all
* Doc for Team routing rule updated to reflect change in behaviour