### PR TITLE
Issue 136/Opsgenie team name allow dot character

### DIFF
--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -213,7 +213,7 @@ func validateOpsGenieTeamName(v interface{}, k string) (ws []string, errors []er
 	value := v.(string)
 	if !regexp.MustCompile(`^[a-zA-Z 0-9_.-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alpha numeric characters and underscores are allowed in %q: %q", k, value))
+			"only alpha numeric characters, dots and underscores are allowed in %q: %q", k, value))
 	}
 
 	if len(value) >= 100 {

--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -211,7 +211,7 @@ func expandOpsGenieTeamMembers(d *schema.ResourceData) []team.Member {
 
 func validateOpsGenieTeamName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z 0-9_-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[a-zA-Z 0-9_.-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only alpha numeric characters and underscores are allowed in %q: %q", k, value))
 	}


### PR DESCRIPTION
Hey
We have opsgenie teams in convention like "client.team". Unfortunately regex in this provider doesn't allow such name.
This PR will allow creating

Closes #136

API allows creation of teams with `.` in name:
```
 curl -X POST https://api.opsgenie.com/v2/teams\
    -H "Content-Type: application/json"\
    -H "Authorization: GenieKey xxx"\
   -d\
'{"name": "test.test.test"}'
{"result":"Created","data":{"id":"8d2325bc-410e-4d0f-ab2e-553acae2ef52","name":"test.test.test"},"took":0.695,"requestId":"c189c723-851c-476e-a3ec-383095ab0f6f"}%
```