### PR TITLE
Added `actions` to `opsgenie_alert_policy`

### DIFF
--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -222,7 +222,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 			"actions": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem: &schema.Schema {
+				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},

--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -219,6 +219,13 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"actions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema {
+					Type: schema.TypeString,
+				},
+			},
 			"ignore_original_responders": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -301,6 +308,7 @@ func resourceOpsGenieAlertPolicyCreate(d *schema.ResourceData, meta interface{})
 		IgnoreOriginalResponders: &ignore_original_responders,
 		IgnoreOriginalTags:       &ignore_original_tags,
 		Priority:                 alert.Priority(priority),
+		Actions:                  flattenOpsgenieAlertPolicyActions(d),
 		Tags:                     flattenOpsgenieAlertPolicyTags(d),
 	}
 
@@ -361,6 +369,7 @@ func resourceOpsGenieAlertPolicyRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("ignore_original_details", policyRes.IgnoreOriginalDetails)
 	d.Set("ignore_original_responders", policyRes.IgnoreOriginalResponders)
 	d.Set("ignore_original_tags", policyRes.IgnoreOriginalTags)
+	d.Set("actions", policyRes.Actions)
 	d.Set("tags", policyRes.Tags)
 
 	if policyRes.Responders != nil {
@@ -418,6 +427,7 @@ func resourceOpsGenieAlertPolicyUpdate(d *schema.ResourceData, meta interface{})
 		IgnoreOriginalResponders: &ignore_original_responders,
 		IgnoreOriginalTags:       &ignore_original_tags,
 		Priority:                 alert.Priority(priority),
+		Actions:                  flattenOpsgenieAlertPolicyActions(d),
 		Tags:                     flattenOpsgenieAlertPolicyTags(d),
 	}
 

--- a/opsgenie/resource_opsgenie_alert_policy_test.go
+++ b/opsgenie/resource_opsgenie_alert_policy_test.go
@@ -241,6 +241,7 @@ func testAccOpsGenieAlertPolicy_complete(randomTeam, randomAlertPolicyName strin
 		id = "${opsgenie_team.test.id}"
 	  }
 	  tags = ["test"]
+	  actions = ["test_action"]
 	}
 	`, randomTeam, randomAlertPolicyName)
 

--- a/website/docs/r/alert_policy.html.markdown
+++ b/website/docs/r/alert_policy.html.markdown
@@ -23,6 +23,8 @@ resource "opsgenie_alert_policy" "test" {
   name               = "example policy"
   team_id            = opsgenie_team.test.id
   policy_description = "This is sample policy"
+  message            = "{{message}}"
+
   filter {}
   time_restriction {
     type = "weekday-and-time-of-day"
@@ -64,7 +66,7 @@ The following arguments are supported:
 
 * `message` - (Required) Message of the alerts
 
-*`continue` - (Optional) It will trigger other modify policies if set to true. Default value is false
+*`continue_policy` - (Optional) It will trigger other modify policies if set to true. Default value is false
 
 * `alias` - (Optional) Alias of the alert. You can use {{alias}} to refer to the original alias. Default value is {{alias}}
 
@@ -83,6 +85,8 @@ The following arguments are supported:
 * `responders` - (Optional) Responders to add to the alerts original responders value as a list of teams, users or the reserved word none or all. If ignoreOriginalResponders field is set to true, this will replace the original responders. The possible values for responders are: user, team. This is a block, structure is documented below.
 
 * `ignore_original_tags` - (Optional) If set to true, policy will ignore the original tags of the alert. Default value is false
+
+* `actions` - (Optional) Actions to add to the alerts original actions value as a list of strings. If ignore_original_actions field is set to true, this will replace the original actions.
 
 * `tags` - (Optional) Tags to add to the alerts original tags value as a list of strings. If ignoreOriginalResponders field is set to true, this will replace the original responders.
 


### PR DESCRIPTION
`actions` are not available within the `opsgenie_alert_policy` but are a necessary part of our workflow. In order to enable them I have replicated the changes that were made to `tags` in `0.3.9` for `actions`.

Added:
  - re-added actions to `resource_opsgenie_alert_policy.go` in a similar
    manner to tag `v.0.3.8` but swapped to use a `schema.TypeSet` instead
    of a list so that it aligns with `flattenOpsgenieAlertPolicyActions`
  - added `Actions` in all locations where `Tags` is present (they
    behave similarly)
  - Added `actions = ["test_action"]` to tests for alert_policy
  - Added `actions` entry in the argument list for the documentation

Fixed:
  - `continue` => `continue_policy` in documentation
  - `message = "{{message}}"` in the example because it is required
