### PR TITLE
Update integration name restrictions

### DIFF
--- a/opsgenie/integration_util.go
+++ b/opsgenie/integration_util.go
@@ -2,7 +2,6 @@ package opsgenie
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -29,20 +28,6 @@ func expandOpsgenieIntegrationResponders(d *schema.ResourceData) []integration.R
 	}
 
 	return responders
-}
-
-func validateOpsgenieIntegrationName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z 0-9_-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alpha numeric characters and underscores are allowed in %q: %q", k, value))
-	}
-
-	if len(value) >= 100 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 100 characters: %q %d", k, value, len(value)))
-	}
-
-	return
 }
 
 func validateResponderType(v interface{}, k string) (ws []string, errors []error) {

--- a/opsgenie/resource_opsgenie_api_integration.go
+++ b/opsgenie/resource_opsgenie_api_integration.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/integration"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 )
@@ -22,7 +23,7 @@ func resourceOpsgenieApiIntegration() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateOpsgenieIntegrationName,
+				ValidateFunc: validation.StringLenBetween(1, 250),
 			},
 			"enabled": {
 				Type:     schema.TypeBool,

--- a/opsgenie/resource_opsgenie_api_integration_test.go
+++ b/opsgenie/resource_opsgenie_api_integration_test.go
@@ -73,6 +73,27 @@ func TestAccOpsGenieApiIntegration_basic(t *testing.T) {
 	})
 }
 
+func TestAccOpsGenieApiIntegration_limits(t *testing.T) {
+	randomLongName := acctest.RandString(245)
+	// include a backtick here as it's not possible to escape it in the multiline string
+	randomName := "`" + acctest.RandString(6)
+	config := testAccOpsGenieApiIntegration_limits(randomLongName, randomName)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckOpsGenieApiIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOpsGenieApiIntegrationExists("opsgenie_api_integration.test_length"),
+					testCheckOpsGenieApiIntegrationExists("opsgenie_api_integration.test_format"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOpsGenieApiIntegration_complete(t *testing.T) {
 	randomUsername := acctest.RandString(6)
 	randomTeam := acctest.RandString(6)
@@ -158,6 +179,20 @@ resource "opsgenie_api_integration" "test" {
   name = "genieintegration-%s"
 }
 `, rString)
+}
+
+func testAccOpsGenieApiIntegration_limits(randomLongName, randomName string) string {
+	return fmt.Sprintf(`
+resource "opsgenie_api_integration" "test_length" {
+  type = "API"
+  name = "test-%s"
+}
+
+resource "opsgenie_api_integration" "test_format" {
+  type = "API"
+  name = "[] () {} 🚒 %s"
+}
+`, randomLongName, randomName)
 }
 
 func testAccOpsGenieApiIntegration_complete(randomUsername, randomTeam, randomTeam2, randomSchedule, randomEscalation, randomIntegration, randomIntegration2 string) string {

--- a/opsgenie/resource_opsgenie_email_integration.go
+++ b/opsgenie/resource_opsgenie_email_integration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/integration"
 )
 
@@ -23,7 +24,7 @@ func resourceOpsgenieEmailIntegration() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateOpsgenieIntegrationName,
+				ValidateFunc: validation.StringLenBetween(1, 250),
 			},
 			"email_username": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
The length limit is not explicitly stated on Opsgenie's documentation,
but when you try creating a resource with more than 250 characters this
is what the API returns:

    Error: Error occurred with Status code: 422, Message: [Integration name] length exceeds the maximum value [250], Took: 0.021000, RequestId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

The format doesn't seem restricted at all, and you can even add emojis
to the integration name. Since the custom validation function would end
up being just a check for the name length, it was replaced with a call
to the validation helpers in each integration.