### PR TITLE
Fix start minute key name

### DIFF
--- a/website/docs/r/notification_policy.html.markdown
+++ b/website/docs/r/notification_policy.html.markdown
@@ -96,9 +96,9 @@ The `restrictions` block supports:
 
 * `end_hour` - (Required) Ending hour of restriction on defined `end_day`
 
-* `start_minute` - (Required) Staring minute of restriction on defined `start_hour`
+* `start_min` - (Required) Staring minute of restriction on defined `start_hour`
 
-* `end_minute` - (Required) Ending minute of restriction on defined `end_hour`
+* `end_min` - (Required) Ending minute of restriction on defined `end_hour`
 
 The `restriction` block supports:
 
@@ -106,9 +106,9 @@ The `restriction` block supports:
 
 * `end_hour` - (Required) Ending hour of restriction.
 
-* `start_minute` - (Required) Staring minute of restriction on defined `start_hour`
+* `start_min` - (Required) Staring minute of restriction on defined `start_hour`
 
-* `end_minute` - (Required) Ending minute of restriction on defined `end_hour`
+* `end_min` - (Required) Ending minute of restriction on defined `end_hour`
 
 The `auto_close_action` block supports:
 


### PR DESCRIPTION
Hello,

The documentation states that time restrictions should use the keys `start_minute` and `end_minute`, but the provider rejects these keys.

The correct keys are `start_min` and `end_min`

Thanks
