### PR TITLE
Update schedule name restriction, mainly allow dots.

### DIFF
--- a/opsgenie/data_resource_opsgenie_schedule.go
+++ b/opsgenie/data_resource_opsgenie_schedule.go
@@ -10,31 +10,8 @@ import (
 
 func dataSourceOpsgenieSchedule() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceOpsgenieScheduleRead,
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateOpsgenieScheduleName,
-			},
-			"description": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateOpsgenieScheduleDescription,
-			},
-			"timezone": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"owner_team_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-		},
+		Read:   dataSourceOpsgenieScheduleRead,
+		Schema: opsgenieScheduleSchema,
 	}
 }
 


### PR DESCRIPTION
Previously, dots in opsgenie_schedule.name were rejected, despite being
allowed both in the UI and in the API. The Schedule API documentation
does not explicitly mention restrictions (other than the 100 character
limit).

As of 2020-11-30, the actual API returns the following error message:

```
Error: Error occurred with Status code: 422, Message:
Name can only contain alphanumeric characters, dots, underscores and dashes.
Leading and trailing spaces are not allowed., Took: 0.081000, RequestId: xyz
```

This makes the ValidateFunc of the field match that.

Use the validate helpers and build the Schema just once.