### PR TITLE
Allow zeroes in until_hour/until_minute under notification_policy.delay_action.

### DIFF
--- a/opsgenie/resource_opsgenie_notification_policy.go
+++ b/opsgenie/resource_opsgenie_notification_policy.go
@@ -262,18 +262,14 @@ func resourceOpsGenieNotificationPolicy() *schema.Resource {
 							}, false),
 						},
 						"until_minute": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							// This should be from 0 to 23 but due to BUG in SDK it has to be more than 1
-							// https://github.com/opsgenie/opsgenie-go-sdk-v2/issues/29
-							ValidateFunc: validation.IntBetween(1, 59),
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 59),
 						},
 						"until_hour": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							// This should be from 0 to 23 but due to BUG in SDK it has to be more than 1
-							// https://github.com/opsgenie/opsgenie-go-sdk-v2/issues/29
-							ValidateFunc: validation.IntBetween(1, 23),
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 23),
 						},
 						"duration": {
 							Type:     schema.TypeList,


### PR DESCRIPTION
The referenced issue
https://github.com/opsgenie/opsgenie-go-sdk-v2/issues/29 has been fixed, hence the workaround in the code can be removed.