### PR TITLE
add "group" as participant for opsgenie_schedule_rotation #230

### DIFF
--- a/opsgenie/resource_opsgenie_schedule_rotation.go
+++ b/opsgenie/resource_opsgenie_schedule_rotation.go
@@ -499,7 +499,7 @@ func validateScheduleRotationParticipantType(v interface{}, k string) (ws []stri
 		"team":       true,
 		"escalation": true,
 		"none":       true,
-		"group":	  true,
+		"group":      true,
 	}
 
 	if !families[value] {

--- a/opsgenie/resource_opsgenie_schedule_rotation.go
+++ b/opsgenie/resource_opsgenie_schedule_rotation.go
@@ -499,10 +499,11 @@ func validateScheduleRotationParticipantType(v interface{}, k string) (ws []stri
 		"team":       true,
 		"escalation": true,
 		"none":       true,
+		"group":	  true,
 	}
 
 	if !families[value] {
-		errors = append(errors, fmt.Errorf("it can only be one of these 'user', 'schedule', 'team', 'escalation'"))
+		errors = append(errors, fmt.Errorf("it can only be one of these 'user', 'schedule', 'team', 'escalation', group"))
 	}
 	return
 }


### PR DESCRIPTION
This MR aims to fix the following behaviour. 

If I do a **terraform import opsgenie_schedule_rotation.test schedule_id/id** and if that rotation has the participant type = group, it gets imported, but then when I try **terraform plan** i get **Error: it can only be one of these 'user', 'schedule', 'team', 'escalation'**

There is also an open issue #230 