### PR TITLE
#233 - Adding additional documented parameters

### DIFF
--- a/opsgenie/resource_opsgenie_service_incident_rule.go
+++ b/opsgenie/resource_opsgenie_service_incident_rule.go
@@ -59,6 +59,7 @@ func resourceOpsGenieServiceIncidentRule() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											"message", "description", "tags",
 											"extra-properties", "recipients", "teams", "priority",
+											"alias", "source", "entity", "actions", "details",
 										}, false),
 									},
 									"operation": {


### PR DESCRIPTION
Raise change to add the additional documented values for `field` property on `opsgenie_service_incident_rule`.`field` as per #233

I've had a quick look at the tests in `testAccOpsGenieServiceIncidentRule_complete` and it appears like there aren't exhaustive tests covering the existing `field` cases - keen for some feedback from maintainers about what approach and level of testing we want for this change.