### PR TITLE
Update user parameters that default to Opsgenie account values

### DIFF
--- a/opsgenie/data_source_opsgenie_user.go
+++ b/opsgenie/data_source_opsgenie_user.go
@@ -32,12 +32,12 @@ func dataSourceOpsGenieUser() *schema.Resource {
 			"locale": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "en_US",
+				Computed: true,
 			},
 			"timezone": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "America/New_York",
+				Computed: true,
 			},
 		},
 	}

--- a/opsgenie/resource_opsgenie_user.go
+++ b/opsgenie/resource_opsgenie_user.go
@@ -42,12 +42,12 @@ func resourceOpsGenieUser() *schema.Resource {
 			"locale": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "en_US",
+				Computed: true,
 			},
 			"timezone": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				Default:          "America/New_York",
+				Computed:         true,
 				DiffSuppressFunc: checkTimeZoneDiff,
 			},
 			"tags": {


### PR DESCRIPTION
PR changes user parameters that default to Opsgenie account values (`locale` & `timezone`) to use Computed instead of Default behavior. 

Fixes #83 (overwriting timezone after import) 

opsgenie.tf:
```
resource "opsgenie_user" "terraform-1" {
  username  = "terraform-user+1@example.net"
  full_name = "Terraform User 1"
  role      = "User"
}
```

tf state after import: 
```
# opsgenie_user.rpratt:
resource "opsgenie_user" "terraform-1" {
    full_name = "Terraform User 1"
    id        = "terraform-user+1@example.net"
    locale    = "en_US"
    role      = "User"
    tags      = []
    timezone  = "America/Adak"
    username  = "terraform-user+1@example.net"
}
```

tf plan: 
```
opsgenie_user.terraform-1: Refreshing state... [id=terraform-user+1@example.net]

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```