### PR TITLE
Allowing periods in heartbeat names

### DIFF
--- a/opsgenie/resource_opsgenie_heartbeat.go
+++ b/opsgenie/resource_opsgenie_heartbeat.go
@@ -199,9 +199,9 @@ func flattenTags(d *schema.ResourceData) []string {
 
 func validateOpsgenieHeartbeat(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[a-zA-Z0-9_-.]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alpha numeric characters and underscores are allowed in %q: %q", k, value))
+			"only alpha numeric characters, underscores (_), dashes (-) and periods (.) are allowed in %q: %q", k, value))
 	}
 
 	if len(value) >= 100 {


### PR DESCRIPTION
Opsgenie permits periods in the names of heartbeats, but these are not supported by the validation of names that the provider does.

Closes #256 