### PR TITLE
Update go to 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
This is consistent with Hashicorp's own terraform providers (e.g see this log output from the snapshot action of`terraform-provider-aws`: https://github.com/hashicorp/terraform-provider-aws/runs/4220840619?check_suite_focus=true), and enables support for Apple Silicon.