### PR TITLE
Add send_via_oec and send_via_marid to createApiIntegration

### DIFF
--- a/opsgenie/resource_opsgenie_api_integration.go
+++ b/opsgenie/resource_opsgenie_api_integration.go
@@ -85,6 +85,16 @@ func resourceOpsgenieApiIntegration() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"send_via_oec": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"send_via_marid": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -124,6 +134,8 @@ func createApiIntegration(d *schema.ResourceData, meta interface{}) error {
 	ownerTeam := d.Get("owner_team_id").(string)
 	integrationType := d.Get("type").(string)
 	enabled := d.Get("enabled").(bool)
+	sendViaOEC := d.Get("send_via_oec").(bool)
+	sendViaMarid := d.Get("send_via_marid").(bool)
 
 	if integrationType == "" {
 		integrationType = ApiIntegrationType
@@ -135,6 +147,8 @@ func createApiIntegration(d *schema.ResourceData, meta interface{}) error {
 		AllowWriteAccess:            &allowWriteAccess,
 		IgnoreRespondersFromPayload: &ignoreRespondersFromPayload,
 		SuppressNotifications:       &suppressNotifications,
+		SendViaOEC:                  &sendViaOEC,
+		SendViaMarid:                &sendViaMarid,
 		Responders:                  expandOpsgenieIntegrationResponders(d),
 	}
 

--- a/opsgenie/resource_opsgenie_api_integration.go
+++ b/opsgenie/resource_opsgenie_api_integration.go
@@ -88,12 +88,10 @@ func resourceOpsgenieApiIntegration() *schema.Resource {
 			"send_via_oec": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"send_via_marid": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 		},
 	}

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/client/client.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/client/client.go
@@ -230,7 +230,7 @@ func setRetryPolicy(opsGenieClient *OpsGenieClient, cfg *Config) {
 }
 
 func NewOpsGenieClient(cfg *Config) (*OpsGenieClient, error) {
-	UserAgentHeader = fmt.Sprintf("opsgenie-go-sdk-%s %s (%s/%s)", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	UserAgentHeader = fmt.Sprintf("opsgenie-go-sdk-%s %s (%s/%s) - Terraform", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	opsGenieClient := &OpsGenieClient{
 		Config:          cfg,
 		RetryableClient: retryablehttp.NewClient(),

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/client/client.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/client/client.go
@@ -230,7 +230,7 @@ func setRetryPolicy(opsGenieClient *OpsGenieClient, cfg *Config) {
 }
 
 func NewOpsGenieClient(cfg *Config) (*OpsGenieClient, error) {
-	UserAgentHeader = fmt.Sprintf("opsgenie-go-sdk-%s %s (%s/%s) - Terraform", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	UserAgentHeader = fmt.Sprintf("opsgenie-go-sdk-%s %s (%s/%s)", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	opsGenieClient := &OpsGenieClient{
 		Config:          cfg,
 		RetryableClient: retryablehttp.NewClient(),

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/integration/request.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/integration/request.go
@@ -51,6 +51,8 @@ type APIBasedIntegrationRequest struct {
 	AllowWriteAccess            *bool         `json:"allowWriteAccess"`
 	IgnoreRespondersFromPayload *bool         `json:"ignoreRespondersFromPayload"`
 	SuppressNotifications       *bool         `json:"suppressNotifications"`
+	SendViaOEC                  *bool         `json:"sendViaOEC,omitempty"`
+	SendViaMarid                *bool         `json:"sendViaMarid,omitempty"`
 	OwnerTeam                   *og.OwnerTeam `json:"ownerTeam,omitempty"`
 	Responders                  []Responder   `json:"responders,omitempty"`
 }

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/integration/result.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/integration/result.go
@@ -166,8 +166,8 @@ const (
 )
 
 type Responder struct {
-	Type     ResponderType `json:"type, omitempty"`
+	Type     ResponderType `json:"type,omitempty"`
 	Name     string        `json:"name,omitempty"`
 	Id       string        `json:"id,omitempty"`
-	Username string        `json:"username, omitempty"`
+	Username string        `json:"username,omitempty"`
 }


### PR DESCRIPTION
I was unable to provision an API integration of the type Zabbix (https://github.com/opsgenie/terraform-provider-opsgenie/issues/285), due to missing arguments that the API requires.

This pull request is to add those required arguments _send_via_oec_ and _send_via_marid_ on the Terraform provider.

I opened a related pull request for the SDK (https://github.com/opsgenie/opsgenie-go-sdk-v2/pull/94).

Can you please review and approve my change!  Thank you!