### PR TITLE
Update README tf logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform Provider
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
+<img src="https://cdn.jsdelivr.net/gh/hashicorp/terraform-website@master/public/img/logo-hashicorp.svg" width="600px">
 
 Requirements
 ------------


### PR DESCRIPTION
`cdn.rawgit.com` has been replaced with `cdn.jsdelivr.net`. This PR fixes the outdated link to the `README` Hasicorp logo (because everyone likes a pretty picture!)