### PR TITLE
Team members are an unordered set of users instead of a list

### DIFF
--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -164,7 +164,7 @@ func resourceOpsGenieTeamUpdate(d *schema.ResourceData, meta interface{}) error 
 		Description: description,
 	}
 
-	if len(d.Get("member").([]interface{})) > 0 && !d.Get("ignore_members").(bool) {
+	if d.Get("member").(*schema.Set).Len() > 0 && !d.Get("ignore_members").(bool) {
 		updateRequest.Members = expandOpsGenieTeamMembers(d)
 	}
 
@@ -210,14 +210,14 @@ func flattenOpsGenieTeamMembers(input []team.Member) []map[string]interface{} {
 }
 
 func expandOpsGenieTeamMembers(d *schema.ResourceData) []team.Member {
-	input := d.Get("member").([]interface{})
-	members := make([]team.Member, 0, len(input))
+	input := d.Get("member").(*schema.Set)
+	members := make([]team.Member, 0, input.Len())
 
 	if input == nil {
 		return members
 	}
 
-	for _, v := range input {
+	for _, v := range input.List() {
 		config := v.(map[string]interface{})
 
 		userId := config["id"].(string)


### PR DESCRIPTION
Members of a team are not sortable and there orders should not matter.

Currently, teams with several members may display changes every time Terraform is run, even if nothing changes (members configured in Terraform and/or members configured in Opsgenie itself.)

Furthermore, the current plan displays a list of user IDs that are being changed: this makes the plan even harder to read as the Terraform operator has to manually map which users correspond to which ID to understand the plan:

```hcl
  # opsgenie_team.main will be updated in-place
  ~ resource "opsgenie_team" "main" {
        id                       = "b7467f00-237e-42c3-8e0d-f0b1966f35aa"
        name                     = "main"
        # (2 unchanged attributes hidden)

      ~ member {
          ~ id   = "bb411771-e3e7-430a-aa04-383c2593e4f2" -> "0ab92f99-ac59-48f7-82d7-d71557111038"
            # (1 unchanged attribute hidden)
        }
      ~ member {
          ~ id   = "db346135-f57c-4292-a6d3-b06c0b9fa1ee" -> "bb411771-e3e7-430a-aa04-383c2593e4f2"
            # (1 unchanged attribute hidden)
        }
      ~ member {
          ~ id   = "7580b351-fe95-45d3-bdb8-feb5665e4a06" -> "db346135-f57c-4292-a6d3-b06c0b9fa1ee"
            # (1 unchanged attribute hidden)
        }
      ~ member {
          ~ id   = "0ab92f99-ac59-48f7-82d7-d71557111038" -> "7580b351-fe95-45d3-bdb8-feb5665e4a06"
            # (1 unchanged attribute hidden)
        }
    }
```

This pull request makes the list of members an *unordered set* of users instead of a *ordered list* and prevent this kind of change to appear in subsequent plans.

Fix #288