### PR TITLE
Correct OpsGenie name validation error message

### DIFF
--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -240,7 +240,7 @@ func validateOpsGenieTeamName(v interface{}, k string) (ws []string, errors []er
 	value := v.(string)
 	if !regexp.MustCompile(`^[a-zA-Z 0-9_.-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alpha numeric characters, dots and underscores are allowed in %q: %q", k, value))
+			"only alphanumeric characters, dots, spaces, hyphens, and underscores are allowed in %q: %q", k, value))
 	}
 
 	if len(value) >= 100 {


### PR DESCRIPTION
The current error message is significantly more strict than the actual regex. This can lead to confusion when creating new teams.