### PR TITLE
Provider crashes when trying to update team members

### DIFF
--- a/opsgenie/resource_opsgenie_team.go
+++ b/opsgenie/resource_opsgenie_team.go
@@ -44,7 +44,7 @@ func resourceOpsGenieTeam() *schema.Resource {
 				Default:  false,
 			},
 			"member": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
aka: Team members are an unordered set of users instead of a list (part 2)

Missing bits for #298.

Without this, the provider crashes when trying to update a team:

```
module.test.opsgenie_team.main: Modifying... [id=f829f421-264d-4fb8-9255-1ee9a072bec4]
╷
│ Error: Plugin did not respond
│
│   with module.test.opsgenie_team.main,
│   on test/teams.tf line 1, in resource "opsgenie_team" "main":
│    1: resource "opsgenie_team" "main" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-opsgenie_v0.6.11 plugin:

panic: interface conversion: interface {} is []interface {}, not *schema.Set

goroutine 57 [running]:
github.com/opsgenie/terraform-provider-opsgenie/opsgenie.resourceOpsGenieTeamUpdate(0xc000496180, 0xbf9ac0, 0xc00000f788, 0x0, 0xffffffffffffffff)
	github.com/opsgenie/terraform-provider-opsgenie/opsgenie/resource_opsgenie_team.go:167 +0x565
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0xc000138540, 0xe4b4f8, 0xc0002774c0, 0xc000496180, 0xbf9ac0, 0xc00000f788, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/schema/resource.go:363 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000138540, 0xe4b4f8, 0xc0002774c0, 0xc0002060d0, 0xc0005afe80, 0xbf9ac0, 0xc00000f788, 0x0, 0x0, 0x0, ...)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/schema/resource.go:475 +0x390
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc00011c780, 0xe4b4f8, 0xc0002774c0, 0xc0001c9220, 0xd517ce, 0x12, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/schema/grpc_provider.go:977 +0xacf
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0000f6500, 0xe4b5a0, 0xc0002774c0, 0xc0001bb180, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:603 +0x465
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0xd12740, 0xc0000f6500, 0xe4b5a0, 0xc0003031d0, 0xc00035c5a0, 0x0, 0xe4b5a0, 0xc0003031d0, 0xc00049cf00, 0x493)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00020cc40, 0xe53af8, 0xc000683200, 0xc000130700, 0xc0001aced0, 0x12cfbe0, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00020cc40, 0xe53af8, 0xc000683200, 0xc000130700, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0001201e0, 0xc00020cc40, 0xe53af8, 0xc000683200, 0xc000130700)
	google.golang.org/grpc@v1.32.0/server.go:859 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x1fd

Error: The terraform-provider-opsgenie_v0.6.11 plugin crashed!
```