### PR TITLE
Reinstates ARM64 build generation for all OS platforms except Windows.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,9 +24,12 @@ builds:
     - amd64
     - '386'
     - arm
+    - arm64
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
ARM64 build generation was turned off in https://github.com/opsgenie/terraform-provider-opsgenie/commit/a7efe767e015f6822ddee8b6711bf3185c1076d9 as a response to CI build breakages that occurred as a result of ARM64 and Windows being an unsupported `GOARCH` and `GOOS` combo as encountered in https://github.com/opsgenie/terraform-provider-opsgenie/runs/7466625010.

This PR, if applied, should selectively disable ARM64 build generation for Windows and Windows alone, thereby allowing ARM64 builds for other OSes to be successfully generated. Which, in turn, would fix https://github.com/opsgenie/terraform-provider-opsgenie/issues/317.