### PR TITLE
Fix send_after check for 0

### DIFF
--- a/opsgenie/resource_opsgenie_notification_rule.go
+++ b/opsgenie/resource_opsgenie_notification_rule.go
@@ -440,7 +440,7 @@ func expandOpsGenieNotificationRuleSteps(input []interface{}) []*og.Step {
 		element := og.Step{}
 		element.Enabled = &enabled
 		element.Contact = expandOpsGenieNotificationRuleStepsContact(config["contact"].([]interface{}))
-		if config["send_after"].(int) > 0 {
+		if config["send_after"].(int) > -1 {
 			element.SendAfter = &og.SendAfter{
 				TimeUnit:   "minute",
 				TimeAmount: uint32(config["send_after"].(int)),

--- a/website/docs/r/notification_rule.html.markdown
+++ b/website/docs/r/notification_rule.html.markdown
@@ -53,7 +53,7 @@ The `steps` block supports:
 
 * `enabled` - (Optional) Defined if this step is enabled. Default: `true`
 
-* `send_after` - (Optional) Time period, in minutes, notification will be sent after.
+* `send_after` - (Optional) Time period, in minutes, notification will be sent after. Should be an integer equal to or higher than 0.
 
 * `contact` - (Required) Defines the contact that notification will be sent to. This is a block, structure is documented below.
 


### PR DESCRIPTION
Currently you cannot set the "send_after" property to 0 for an opsgenie_notification_rule. This means that you can only set it to 1 or higher and not "0" which means that a notification is send immediately.

This pull request should probably fix that by changing the if statement to check if the int is greater than -1 instead of 0 (and thus allowing 0).

Please review this and merge. This is preventing us from properly onboarding users to our environment.