### PR TITLE
Fix broken logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform Provider
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
+<img src="https://www.datocms-assets.com/2885/1629941242-logo-terraform-main.svg" width="600px">
 
 Requirements
 ------------


### PR DESCRIPTION
We have cherry-picked commit from https://github.com/opsgenie/terraform-provider-opsgenie/pull/331