### PR TITLE
fix: Alert policy filter conditions/time restrictions/responders should be set, not an ordered list.

### DIFF
--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -129,7 +129,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"time-of-day", "weekday-and-time-of-day"}, false),
 						},
 						"restrictions": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -161,7 +161,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 							},
 						},
 						"restriction": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -568,9 +568,9 @@ func expandOpsGenieAlertPolicyTimeRestriction(d []interface{}) *og.TimeRestricti
 	for _, v := range d {
 		config := v.(map[string]interface{})
 		timeRestriction.Type = og.RestrictionType(config["type"].(string))
-		if len(config["restrictions"].([]interface{})) > 0 {
-			restrictionList := make([]og.Restriction, 0, len(config["restrictions"].([]interface{})))
-			for _, v := range config["restrictions"].([]interface{}) {
+		if config["restrictions"].(*schema.Set).Len() > 0 {
+			restrictionList := make([]og.Restriction, 0, config["restrictions"].(*schema.Set).Len())
+			for _, v := range config["restrictions"].(*schema.Set).List() {
 				config := v.(map[string]interface{})
 				startHour := uint32(config["start_hour"].(int))
 				startMin := uint32(config["start_min"].(int))
@@ -589,7 +589,7 @@ func expandOpsGenieAlertPolicyTimeRestriction(d []interface{}) *og.TimeRestricti
 			timeRestriction.RestrictionList = restrictionList
 		} else {
 			restriction := og.Restriction{}
-			for _, v := range config["restriction"].([]interface{}) {
+			for _, v := range config["restriction"].(*schema.Set).List() {
 				config := v.(map[string]interface{})
 				startHour := uint32(config["start_hour"].(int))
 				startMin := uint32(config["start_min"].(int))

--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -239,7 +239,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 				Default:  false,
 			},
 			"responders": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -319,7 +319,7 @@ func resourceOpsGenieAlertPolicyCreate(ctx context.Context, d *schema.ResourceDa
 		Tags:                     flattenOpsgenieAlertPolicyTags(d),
 	}
 
-	if len(d.Get("responders").([]interface{})) > 0 {
+	if d.Get("responders").(*schema.Set).Len() > 0 {
 		createRequest.Responders = expandOpsGenieAlertPolicyResponders(d)
 	}
 
@@ -438,7 +438,7 @@ func resourceOpsGenieAlertPolicyUpdate(d *schema.ResourceData, meta interface{})
 		Tags:                     flattenOpsgenieAlertPolicyTags(d),
 	}
 
-	if len(d.Get("responders").([]interface{})) > 0 {
+	if d.Get("responders").(*schema.Set).Len() > 0 {
 		updateRequest.Responders = expandOpsGenieAlertPolicyResponders(d)
 	}
 
@@ -500,14 +500,14 @@ func expandOpsGenieAlertPolicyRequestMainFields(d *schema.ResourceData) *policy.
 }
 
 func expandOpsGenieAlertPolicyResponders(d *schema.ResourceData) *[]alert.Responder {
-	input := d.Get("responders").([]interface{})
-	responders := make([]alert.Responder, 0, len(input))
+	input := d.Get("responders").(*schema.Set)
+	responders := make([]alert.Responder, 0, input.Len())
 
 	if input == nil {
 		return &responders
 	}
 
-	for _, v := range input {
+	for _, v := range input.List() {
 		config := v.(map[string]interface{})
 		responderID := config["id"].(string)
 		name := config["name"].(string)


### PR DESCRIPTION
Similar to https://github.com/opsgenie/terraform-provider-opsgenie/pull/338.

Fixes several open issues related to ordering of elements inside the `opsgenie_alert_policy` resource block:
https://github.com/opsgenie/terraform-provider-opsgenie/issues/387
https://github.com/opsgenie/terraform-provider-opsgenie/issues/226
https://github.com/opsgenie/terraform-provider-opsgenie/issues/191
https://github.com/opsgenie/terraform-provider-opsgenie/issues/133 (?)