### PR TITLE
Add escalation schedule responder in alert policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.27 (July 11, 2023)
+* IMPROVEMENTS:
+  * **Alert Policy:**
+    * Added support for `escalation` and `schedule` type in `responders` field.
+  * **Dev Loop**
+    * Added a hook in goreleaser to generate the local terraform binary/exe to ease debugging.
+
 ## 0.6.26 (June 29, 2023)
 * BUGFIX:
   * **Notification Rule:**
@@ -13,7 +20,6 @@
     * Fixed ignore_original_actions and ignore_original_details being switched.
     * Added `{{description}}` as default value for `alert_description` field to solve [#290](https://github.com/opsgenie/terraform-provider-opsgenie/issues/290).
   * **Team:** Fixed error message to better explain the restrictions around team names.
-
 
 ## 0.6.24 (May 26, 2023)
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
-	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.19
+	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.20
 	github.com/pkg/errors v0.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.19 h1:JernwK3Bgd5x+UJPV6S2LPYoBF+DFOYBoQ5JeJPVBNc=
-github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.19/go.mod h1:4OjcxgwdXzezqytxN534MooNmrxRD50geWZxTD7845s=
+github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.20 h1:twA4Kiaw+Vi4x5Ei3qDO1TtQf7oSuJQ+CqJB9j9lEmQ=
+github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.20/go.mod h1:4OjcxgwdXzezqytxN534MooNmrxRD50geWZxTD7845s=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -245,7 +245,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"user", "team"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"user", "team", "escalation"}, false),
 						},
 						"name": {
 							Type:     schema.TypeString,

--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -245,7 +245,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"user", "team", "escalation"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"user", "team", "escalation", "schedule"}, false),
 						},
 						"name": {
 							Type:     schema.TypeString,

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/notification/request.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/notification/request.go
@@ -558,6 +558,9 @@ func validateStep(step *og.Step, actionType ActionType) error {
 	if step.Contact.MethodOfContact == "" {
 		return errors.New("Method cannot be empty.")
 	}
+	if (actionType == CreateAlert || actionType == AssignedAlert) && step.SendAfter == nil {
+		return errors.New("SendAfter cannot be empty.")
+	}
 
 	return nil
 }

--- a/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/policy/request.go
+++ b/vendor/github.com/opsgenie/opsgenie-go-sdk-v2/policy/request.go
@@ -681,8 +681,8 @@ func ValidateDelayAction(action DelayAction) error {
 
 func ValidateResponders(responders *[]alert.Responder) error {
 	for _, responder := range *responders {
-		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder {
-			return errors.New("responder type for alert policy should be one of team or user")
+		if responder.Type != alert.UserResponder && responder.Type != alert.TeamResponder && responder.Type != alert.EscalationResponder && responder.Type != alert.ScheduleResponder {
+			return errors.New("responder type for alert policy should be one of team, user, escalation or schedule")
 		}
 		if responder.Id == "" {
 			return errors.New("responder id should be provided")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 ## explicit
 github.com/oklog/run
-# github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.19
+# github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.20
 ## explicit; go 1.12
 github.com/opsgenie/opsgenie-go-sdk-v2/alert
 github.com/opsgenie/opsgenie-go-sdk-v2/client

--- a/website/docs/r/alert_policy.html.markdown
+++ b/website/docs/r/alert_policy.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `ignore_original_responders` - (Optional) If set to `true`, policy will ignore the original responders of the alert. Default: `false`
 
-* `responders` - (Optional) Responders to add to the alerts original responders value as a list of teams, users or the reserved word none or all. If `ignore_original_responders` field is set to `true`, this will replace the original responders. The possible values for responders are: `user`, `team`. This is a block, structure is documented below.
+* `responders` - (Optional) Responders to add to the alerts original responders value as a list of teams, users or the reserved word none or all. If `ignore_original_responders` field is set to `true`, this will replace the original responders. The possible values for responders are: `user`, `team`, `escalation`. This is a block, structure is documented below.
 
 * `ignore_original_tags` - (Optional) If set to `true`, policy will ignore the original tags of the alert. Default: `false`
 
@@ -148,7 +148,7 @@ The `restriction` block supports:
 
 The `responders` block supports:
 
-* `type` - (Required) Type of responder. Acceptable values are: `user` or `team`
+* `type` - (Required) Type of responder. Acceptable values are: `user`, `team` or `escalation`
 
 * `name` - (Optional) Name of the responder
 

--- a/website/docs/r/alert_policy.html.markdown
+++ b/website/docs/r/alert_policy.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `ignore_original_responders` - (Optional) If set to `true`, policy will ignore the original responders of the alert. Default: `false`
 
-* `responders` - (Optional) Responders to add to the alerts original responders value as a list of teams, users or the reserved word none or all. If `ignore_original_responders` field is set to `true`, this will replace the original responders. The possible values for responders are: `user`, `team`, `escalation`. This is a block, structure is documented below.
+* `responders` - (Optional) Responders to add to the alerts original responders value as a list of teams, users or the reserved word none or all. If `ignore_original_responders` field is set to `true`, this will replace the original responders. The possible values for responders are: `user`, `team`, `escalation`, `schedule`. This is a block, structure is documented below.
 
 * `ignore_original_tags` - (Optional) If set to `true`, policy will ignore the original tags of the alert. Default: `false`
 
@@ -148,7 +148,7 @@ The `restriction` block supports:
 
 The `responders` block supports:
 
-* `type` - (Required) Type of responder. Acceptable values are: `user`, `team` or `escalation`
+* `type` - (Required) Type of responder. Acceptable values are: `user`, `team`, `escalation` or `schedule`
 
 * `name` - (Optional) Name of the responder
 


### PR DESCRIPTION
This solves https://github.com/opsgenie/terraform-provider-opsgenie/issues/293 by adding support for `escalation` and `schedule` in `responders` in alert policy.