### PR TITLE
Refactor `time_restriction` and stabilise plans containing `notification_rule.steps`, `notification_policy.filter.conditions` and `time_restrictions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
+## 0.6.34 (November 06, 2023)
+* BUGFIX: [#404](https://github.com/opsgenie/terraform-provider-opsgenie/pulls/404)
+  * **Notification Policy:**
+    * Fixed perpetual drift for policies when filters contain more than one condition.
+  * **time_restriction:**
+    * Fixed perpetual drift for `notification/alert policies`, `notification/team_routing rules` and `schedule_rotation` containing `time_restriction` blocks.
+  * **Notification Rule:**
+    * Fixed perpetual drift for rules when they contain more than one step.
+
+* IMPROVEMENTS: [#404](https://github.com/opsgenie/terraform-provider-opsgenie/pulls/404)
+  * **time_restriction:**
+    * Added further schema validation to make it easier to type valid `time_restriction` blocks when using the `terraform-ls` language server.
+  * **Notification Policy:**
+    * Added further schema validation to make it easier to add multiple `action` blocks when using the `terraform-ls` language server.
+
 ## 0.6.28 (July 13, 2023)
 * BUGFIX:
   * **API Integration:**
     * Fixes an issue where owner team could not be updated when the API integration is linked with an Integration action.
-
 
 ## 0.6.27 (July 11, 2023)
 * IMPROVEMENTS:

--- a/opsgenie/commonschema.go
+++ b/opsgenie/commonschema.go
@@ -1,0 +1,92 @@
+package opsgenie
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func timeRestrictionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"time-of-day", "weekday-and-time-of-day"}, false),
+				},
+				"restrictions": {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					ConflictsWith: []string{"time_restriction.0.restriction"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"start_day": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice([]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}, false),
+							},
+							"end_day": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice([]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}, false),
+							},
+							"start_hour": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 23),
+							},
+							"start_min": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 59),
+							},
+							"end_hour": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 23),
+							},
+							"end_min": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 59),
+							},
+						},
+					},
+				},
+				"restriction": {
+					Type:          schema.TypeSet,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{"time_restriction.0.restrictions"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"start_hour": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 23),
+							},
+							"start_min": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 59),
+							},
+							"end_hour": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 23),
+							},
+							"end_min": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(0, 59),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -62,6 +62,7 @@ func resourceOpsGenieAlertPolicy() *schema.Resource {
 			"filter": {
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {

--- a/opsgenie/resource_opsgenie_notification_policy.go
+++ b/opsgenie/resource_opsgenie_notification_policy.go
@@ -127,80 +127,7 @@ func resourceOpsGenieNotificationPolicy() *schema.Resource {
 					},
 				},
 			},
-			"time_restriction": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"time-of-day", "weekday-and-time-of-day"}, false),
-						},
-						"restrictions": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"time_restriction.0.restriction"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"start_day": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"end_day": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"start_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"start_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-						"restriction": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"time_restriction.0.restrictions"},
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"start_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"start_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			"time_restriction": timeRestrictionSchema(),
 			"auto_close_action": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -383,7 +310,7 @@ func resourceOpsGenieNotificationPolicyRead(d *schema.ResourceData, meta interfa
 	}
 	if policy.MainFields.TimeRestriction != nil {
 		log.Printf("[DEBUG] 'policy.MainFields.TimeRestriction' is not 'nil'.")
-		d.Set("time_restriction", flattenOpsgenieNotificationPolicyTimeRestriction(policy.MainFields.TimeRestriction))
+		d.Set("time_restriction", flattenOpsgenieTimeRestriction(policy.MainFields.TimeRestriction))
 	} else {
 		log.Printf("[DEBUG] 'policy.MainFields.TimeRestriction' is 'nil'.")
 		d.Set("time_restriction", nil)
@@ -458,7 +385,7 @@ func expandOpsGenieNotificationPolicyRequestMainFields(d *schema.ResourceData) *
 		fields.Filter = expandOpsGenieNotificationPolicyFilter(d.Get("filter").([]interface{}))
 	}
 	if len(d.Get("time_restriction").([]interface{})) > 0 {
-		fields.TimeRestriction = expandOpsGenieNotificationPolicyTimeRestriction(d.Get("time_restriction").([]interface{}))
+		fields.TimeRestriction = expandOpsGenieTimeRestriction(d.Get("time_restriction").([]interface{}))
 	}
 	return &fields
 }
@@ -579,52 +506,6 @@ func expandOpsGenieNotificationPolicyFilterConditions(input *schema.Set) []og.Co
 	return conditions
 }
 
-func expandOpsGenieNotificationPolicyTimeRestriction(d []interface{}) *og.TimeRestriction {
-	timeRestriction := og.TimeRestriction{}
-	for _, v := range d {
-		config := v.(map[string]interface{})
-		timeRestriction.Type = og.RestrictionType(config["type"].(string))
-		if len(config["restrictions"].([]interface{})) > 0 {
-			restrictionList := make([]og.Restriction, 0, len(config["restrictions"].([]interface{})))
-			for _, v := range config["restrictions"].([]interface{}) {
-				config := v.(map[string]interface{})
-				startHour := uint32(config["start_hour"].(int))
-				startMin := uint32(config["start_min"].(int))
-				endHour := uint32(config["end_hour"].(int))
-				endMin := uint32(config["end_min"].(int))
-				restriction := og.Restriction{
-					StartDay:  og.Day(config["start_day"].(string)),
-					StartHour: &startHour,
-					StartMin:  &startMin,
-					EndHour:   &endHour,
-					EndDay:    og.Day(config["end_day"].(string)),
-					EndMin:    &endMin,
-				}
-				restrictionList = append(restrictionList, restriction)
-			}
-			timeRestriction.RestrictionList = restrictionList
-		} else {
-			restriction := og.Restriction{}
-			for _, v := range config["restriction"].([]interface{}) {
-				config := v.(map[string]interface{})
-				startHour := uint32(config["start_hour"].(int))
-				startMin := uint32(config["start_min"].(int))
-				endHour := uint32(config["end_hour"].(int))
-				endMin := uint32(config["end_min"].(int))
-				restriction = og.Restriction{
-					StartHour: &startHour,
-					StartMin:  &startMin,
-					EndHour:   &endHour,
-					EndMin:    &endMin,
-				}
-			}
-
-			timeRestriction.Restriction = restriction
-		}
-	}
-	return &timeRestriction
-}
-
 func flattenOpsGenieNotificationPolicyDuration(input *policy.Duration) []map[string]interface{} {
 	output := make([]map[string]interface{}, 0, 1)
 	element := make(map[string]interface{})
@@ -705,36 +586,5 @@ func flattenOpsGenieNotificationPolicyFilterConditions(input []og.Condition) []m
 		output = append(output, element)
 	}
 
-	return output
-}
-
-func flattenOpsgenieNotificationPolicyTimeRestriction(input *og.TimeRestriction) []map[string]interface{} {
-	output := make([]map[string]interface{}, 0, 1)
-	element := make(map[string]interface{})
-	if len(input.RestrictionList) > 0 {
-		restrictions := make([]map[string]interface{}, 0, len(input.RestrictionList))
-		for _, r := range input.RestrictionList {
-			restrictionMap := make(map[string]interface{})
-			restrictionMap["start_min"] = r.StartMin
-			restrictionMap["start_hour"] = r.StartHour
-			restrictionMap["start_day"] = r.StartDay
-			restrictionMap["end_min"] = r.EndMin
-			restrictionMap["end_hour"] = r.EndHour
-			restrictionMap["end_day"] = r.EndDay
-			restrictions = append(restrictions, restrictionMap)
-		}
-		element["restrictions"] = restrictions
-	} else {
-		restriction := make([]map[string]interface{}, 0, 1)
-		restrictionMap := make(map[string]interface{})
-		restrictionMap["start_min"] = input.Restriction.StartMin
-		restrictionMap["start_hour"] = input.Restriction.StartHour
-		restrictionMap["end_min"] = input.Restriction.EndMin
-		restrictionMap["end_hour"] = input.Restriction.EndHour
-		restriction = append(restriction, restrictionMap)
-		element["restriction"] = restriction
-	}
-	element["type"] = input.Type
-	output = append(output, element)
 	return output
 }

--- a/opsgenie/resource_opsgenie_notification_rule.go
+++ b/opsgenie/resource_opsgenie_notification_rule.go
@@ -61,7 +61,7 @@ func resourceOpsGenieNotificationRule() *schema.Resource {
 				},
 			},
 			"steps": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -285,8 +285,8 @@ func resourceOpsGenieNotificationRuleCreate(d *schema.ResourceData, meta interfa
 		createRequest.Schedules = expandOpsGenieNotificationRuleSchedules(d.Get("schedules").([]interface{}))
 	}
 
-	if len(d.Get("steps").([]interface{})) > 0 {
-		createRequest.Steps = expandOpsGenieNotificationRuleSteps(d.Get("steps").([]interface{}))
+	if d.Get("steps").(*schema.Set).Len() > 0 {
+		createRequest.Steps = expandOpsGenieNotificationRuleSteps(d.Get("steps").(*schema.Set))
 	}
 
 	if len(timeRestriction) > 0 {
@@ -380,8 +380,8 @@ func resourceOpsGenieNotificationRuleUpdate(d *schema.ResourceData, meta interfa
 		updateRequest.Schedules = expandOpsGenieNotificationRuleSchedules(d.Get("schedules").([]interface{}))
 	}
 
-	if len(d.Get("steps").([]interface{})) > 0 {
-		updateRequest.Steps = expandOpsGenieNotificationRuleSteps(d.Get("steps").([]interface{}))
+	if d.Get("steps").(*schema.Set).Len() > 0 {
+		updateRequest.Steps = expandOpsGenieNotificationRuleSteps(d.Get("steps").(*schema.Set))
 	}
 
 	if len(timeRestriction) > 0 {
@@ -430,12 +430,13 @@ func expandOpsGenieNotificationRuleNotificationTime(input *schema.Set) []notific
 	return output
 }
 
-func expandOpsGenieNotificationRuleSteps(input []interface{}) []*og.Step {
-	output := make([]*og.Step, 0)
+func expandOpsGenieNotificationRuleSteps(input *schema.Set) []*og.Step {
+	output := make([]*og.Step, 0, input.Len())
 	if input == nil {
 		return output
 	}
-	for _, v := range input {
+
+	for _, v := range input.List() {
 		config := v.(map[string]interface{})
 		enabled := config["enabled"].(bool)
 		element := og.Step{}

--- a/opsgenie/resource_opsgenie_notification_rule.go
+++ b/opsgenie/resource_opsgenie_notification_rule.go
@@ -122,74 +122,7 @@ func resourceOpsGenieNotificationRule() *schema.Resource {
 					},
 				},
 			},
-			"time_restriction": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"restrictions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"start_day": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"end_day": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"start_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"start_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-						"restriction": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"start_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"start_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_hour": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"end_min": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			"time_restriction": timeRestrictionSchema(),
 			"schedules": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -290,7 +223,7 @@ func resourceOpsGenieNotificationRuleCreate(d *schema.ResourceData, meta interfa
 	}
 
 	if len(timeRestriction) > 0 {
-		createRequest.TimeRestriction = expandNotificationRuleRestrictions(timeRestriction)
+		createRequest.TimeRestriction = expandOpsGenieTimeRestriction(timeRestriction)
 	}
 
 	log.Printf("[INFO] Creating Notification Rule '%s' for User: '%s'", d.Get("name").(string), d.Get("username").(string))
@@ -331,7 +264,7 @@ func resourceOpsGenieNotificationRuleRead(d *schema.ResourceData, meta interface
 		d.Set("schedules", flattenNotificationSchedules(rule.Schedules))
 	}
 	if rule.TimeRestriction != nil {
-		d.Set("time_restriction", flattenOpsgenieNotificationRuleTimeRestriction(rule.TimeRestriction))
+		d.Set("time_restriction", flattenOpsgenieTimeRestriction(rule.TimeRestriction))
 	} else {
 		d.Set("time_restriction", nil)
 	}
@@ -385,7 +318,7 @@ func resourceOpsGenieNotificationRuleUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if len(timeRestriction) > 0 {
-		updateRequest.TimeRestriction = expandNotificationRuleRestrictions(timeRestriction)
+		updateRequest.TimeRestriction = expandOpsGenieTimeRestriction(timeRestriction)
 	}
 
 	log.Printf("[INFO] Updating Notification Rule '%s' for User: '%s'", d.Get("name").(string), d.Get("username").(string))
@@ -498,59 +431,6 @@ func expandOpsGenieNotificationRuleRepeat(input []interface{}) *notification.Rep
 		repeat.Enabled = &repeatEnabled
 	}
 	return &repeat
-}
-func expandNotificationRuleRestrictions(d []interface{}) *og.TimeRestriction {
-	timeRestriction := og.TimeRestriction{}
-
-	for _, v := range d {
-		config := v.(map[string]interface{})
-
-		timeRestrictionType := config["type"].(string)
-		timeRestriction.Type = og.RestrictionType(timeRestrictionType)
-
-		if len(config["restrictions"].([]interface{})) > 0 {
-			timeRestriction.RestrictionList = expandOpsgenieRestrictions(config["restrictions"].([]interface{}))
-		} else {
-			timeRestriction.Restriction = expandOpsgenieRestriction(config["restriction"].([]interface{}))
-		}
-	}
-
-	return &timeRestriction
-}
-
-func flattenOpsgenieNotificationRuleTimeRestriction(input *og.TimeRestriction) []map[string]interface{} {
-	rules := make([]map[string]interface{}, 0, 1)
-	out := make(map[string]interface{})
-	out["type"] = input.Type
-
-	if len(input.RestrictionList) > 0 {
-		restrictions := make([]map[string]interface{}, 0, len(input.RestrictionList))
-		for _, r := range input.RestrictionList {
-			restrictionMap := make(map[string]interface{})
-			restrictionMap["start_day"] = r.StartDay
-			restrictionMap["end_day"] = r.EndDay
-			restrictionMap["start_hour"] = r.StartHour
-			restrictionMap["start_min"] = r.StartMin
-			restrictionMap["end_hour"] = r.EndHour
-			restrictionMap["end_min"] = r.EndMin
-			restrictions = append(restrictions, restrictionMap)
-		}
-		out["restrictions"] = restrictions
-		rules = append(rules, out)
-		return rules
-	} else {
-		restriction := make(map[string]interface{})
-		//IF RESTRICTION
-		restriction["start_hour"] = input.Restriction.StartHour
-		restriction["start_min"] = input.Restriction.StartMin
-		restriction["end_hour"] = input.Restriction.EndHour
-		restriction["end_min"] = input.Restriction.EndMin
-
-		out["restriction"] = []map[string]interface{}{restriction}
-		rules = append(rules, out)
-
-		return rules
-	}
 }
 
 func expandOpsGenieNotificationRuleSchedules(input []interface{}) []notification.Schedule {

--- a/opsgenie/util.go
+++ b/opsgenie/util.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
+	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
 )
 
 // handleNonExistentResource is a wrapper of resourceFunc that
@@ -88,4 +89,85 @@ func flattenTags(d *schema.ResourceData, fieldName string) []string {
 	}
 
 	return tags
+}
+
+func expandOpsGenieTimeRestriction(d []interface{}) *og.TimeRestriction {
+	timeRestriction := og.TimeRestriction{}
+
+	for _, v := range d {
+		config := v.(map[string]interface{})
+		timeRestriction.Type = og.RestrictionType(config["type"].(string))
+
+		if config["restrictions"].(*schema.Set).Len() > 0 {
+			restrictionList := make([]og.Restriction, 0, config["restrictions"].(*schema.Set).Len())
+			for _, v := range config["restrictions"].(*schema.Set).List() {
+				config := v.(map[string]interface{})
+				startHour := uint32(config["start_hour"].(int))
+				startMin := uint32(config["start_min"].(int))
+				endHour := uint32(config["end_hour"].(int))
+				endMin := uint32(config["end_min"].(int))
+				restriction := og.Restriction{
+					StartDay:  og.Day(config["start_day"].(string)),
+					StartHour: &startHour,
+					StartMin:  &startMin,
+					EndHour:   &endHour,
+					EndDay:    og.Day(config["end_day"].(string)),
+					EndMin:    &endMin,
+				}
+				restrictionList = append(restrictionList, restriction)
+			}
+			timeRestriction.RestrictionList = restrictionList
+		} else {
+			restriction := og.Restriction{}
+			for _, v := range config["restriction"].(*schema.Set).List() {
+				config := v.(map[string]interface{})
+				startHour := uint32(config["start_hour"].(int))
+				startMin := uint32(config["start_min"].(int))
+				endHour := uint32(config["end_hour"].(int))
+				endMin := uint32(config["end_min"].(int))
+				restriction = og.Restriction{
+					StartHour: &startHour,
+					StartMin:  &startMin,
+					EndHour:   &endHour,
+					EndMin:    &endMin,
+				}
+			}
+
+			timeRestriction.Restriction = restriction
+		}
+	}
+	return &timeRestriction
+}
+
+func flattenOpsgenieTimeRestriction(input *og.TimeRestriction) []map[string]interface{} {
+	output := make([]map[string]interface{}, 0, 1)
+	element := make(map[string]interface{})
+
+	if len(input.RestrictionList) > 0 {
+		restrictions := make([]map[string]interface{}, 0, len(input.RestrictionList))
+		for _, r := range input.RestrictionList {
+			restrictionMap := make(map[string]interface{})
+			restrictionMap["start_min"] = r.StartMin
+			restrictionMap["start_hour"] = r.StartHour
+			restrictionMap["start_day"] = r.StartDay
+			restrictionMap["end_min"] = r.EndMin
+			restrictionMap["end_hour"] = r.EndHour
+			restrictionMap["end_day"] = r.EndDay
+			restrictions = append(restrictions, restrictionMap)
+		}
+		element["restrictions"] = restrictions
+	} else {
+		restriction := make([]map[string]interface{}, 0, 1)
+		restrictionMap := make(map[string]interface{})
+		restrictionMap["start_min"] = input.Restriction.StartMin
+		restrictionMap["start_hour"] = input.Restriction.StartHour
+		restrictionMap["end_min"] = input.Restriction.EndMin
+		restrictionMap["end_hour"] = input.Restriction.EndHour
+		restriction = append(restriction, restrictionMap)
+		element["restriction"] = restriction
+	}
+
+	element["type"] = input.Type
+	output = append(output, element)
+	return output
 }

--- a/website/docs/r/notification_policy.html.markdown
+++ b/website/docs/r/notification_policy.html.markdown
@@ -29,6 +29,7 @@ resource "opsgenie_notification_policy" "test" {
     until_hour   = 9
   }
   filter {}
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
Commits:
1. Closes #246

2. Closes #253 And #409
    And adds some much needed schema validation for Terraform-ls to use.

3. Closes #341: 
    Unifies the Schema, Input-Validation, and `expanding/flattening` for `time_restriction` blocks.
    This implementation should fix unstable plans containing `time_restriction` for all resources. 
    #225 only addressed a single resource.

4. Closes #355 
    Way stricter input validation of actions before `terraform apply`

This is a pretty big PR solely because of the `time_restriction` refactor, I am willing to split it, but I do still think reviewing this PR one commit at a time is feasible.