### PR TITLE
Update the `README` setup instructions and Make commands

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,45 +5,48 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - freebsd
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-    - goos: windows
-      goarch: arm64
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
-  hooks:
-    post:
-      - cmd: "sh ./scripts/local-release.sh {{ .Version }} {{ .Path }} {{.Os}} {{.Arch}}"
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: windows
+        goarch: arm64
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    hooks:
+      post:
+        - cmd: "go install ."
+
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # if you are using this is a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -52,8 +55,9 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-release:
-  # Visit your project's GitHub Releases page to publish this release.
+
+release: # Visit your project's GitHub Releases page to publish this release.
   draft: true
+
 changelog:
   skip: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,6 +14,9 @@ dev: fmt
 setup:
 	@sh -c "'$(CURDIR)/scripts/setup.sh'"
 
+clean:
+	rm $(HOME)/.terraformrc
+
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,13 @@ PKG_NAME=opsgenie
 default: build
 
 build: fmtcheck
-	goreleaser build --skip-validate --rm-dist
+	goreleaser build --skip-validate --clean
+
+dev: fmt
+	go install .
+
+setup:
+	@sh -c "'$(CURDIR)/scripts/setup.sh'"
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1
@@ -56,5 +62,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+.PHONY: build dev test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,5 +65,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build dev test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+.PHONY: build dev setup clean test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
 

--- a/scripts/local-release.sh
+++ b/scripts/local-release.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-VERSION=$1
-FILE_PATH=$2
-OS=$3
-ARCH=$4
-
-mkdir -p ~/terraform/providers/test.local/opsgenie/opsgenie/$VERSION/"$OS"_"$ARCH"
-cp $FILE_PATH ~/terraform/providers/test.local/opsgenie/opsgenie/$VERSION/"$OS"_"$ARCH"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$GOPATH" ]; then
+  GOPATH="${GOPATH:-$HOME/go}"
+fi
+
+if [ ! -d "$GOPATH" ]; then
+  mkdir -p "$GOPATH/bin"
+fi
+
+cat >~/.terraformrc <<EOF
+provider_installation {
+  dev_overrides {
+    "opsgenie/opsgenie" = "$GOPATH/bin"
+  }
+  direct {}
+}
+EOF


### PR DESCRIPTION
I had significant trouble getting started with the development of the Provider due the `README.md` not being easy to read.
And I also found the local testing section using test.local to be difficult at best to make use of.

Changes:
- Refactor `README.md`.
  - Remove duplicate sections (Cloning and Building).
  - Order and organise everything und the new `Development` Section/header.
  - Migrate to using the [`dev_overrides`](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) in `$HOME/.terraformrc` to simplify local testing, especially on existing configurations.
  - Expand on the basic Terraform project example (`main.tf`).
  - Remove references to unused `testacc` sub command.
  - Update Golang version from `1.14` -> `1.18` (The one used in the CI)

- Refactor `.goreleaser`
  - fix [YAMLlint](https://github.com/adrienverge/yamllint) errors.
  - `hooks.post` now calls `go install .` As part of the new `dev_overrides` workflow.

- Removed the `scripts/local-release.sh` as it is no longer used anywhere.

- 3 new `GNUmakefile` sub-commands.
  - `setup` Create the `$HOME/.terraformrc` automatically.
  - `dev` Skip compiling all versions. and uses `go install .`
  - `clean` Delete the `$HOME/.terraformrc` restoring normal `terraform plan/apply` behaviour.