### PR TITLE
Fix time_restriction argument in team_routing_rule resource documentation

### DIFF
--- a/website/docs/r/team_routing_rule.html.markdown
+++ b/website/docs/r/team_routing_rule.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `criteria` - (Optional) You can refer Criteria for detailed information about criteria and its fields
 
-* `timeRestriction` - (Optional) You can refer Time Restriction for detailed information about time restriction and its fields.
+* `time_restriction` - (Optional) You can refer Time Restriction for detailed information about time restriction and its fields.
 
 * `notify` - (Required) Target entity of schedule, escalation, or the reserved word none which will be notified in routing rule. The possible values are: `schedule`, `escalation`, `none`
 


### PR DESCRIPTION
As you can see in the documentnation, the `time_restriction` block in the argument reference has a wrong name:

https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/team_routing_rule#timeRestriction

![image](https://github.com/opsgenie/terraform-provider-opsgenie/assets/9192031/1dd6ef45-0cb0-48ae-a6e4-a6a2e95a971f)

