### PR TITLE
Improve alert policy error handling

### DIFF
--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -291,7 +291,7 @@ func resourceOpsGenieAlertPolicyRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		x := err.(*ogClient.ApiError)
 		if x.StatusCode == 404 {
-			tflog.Warn(ctx, fmt.Sprintf("[WARN] Removing Alert Policy because it's gone %s", name))
+			tflog.Warn(ctx, fmt.Sprintf("Removing Alert Policy because it's gone %s", name))
 			d.SetId("")
 			return nil
 		} else if x.StatusCode >= 400 {

--- a/opsgenie/resource_opsgenie_alert_policy.go
+++ b/opsgenie/resource_opsgenie_alert_policy.go
@@ -291,13 +291,11 @@ func resourceOpsGenieAlertPolicyRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		x := err.(*ogClient.ApiError)
 		if x.StatusCode == 404 {
-			errText := fmt.Sprintf("[WARN] Removing Alert Policy because it's gone %s", name)
-			tflog.Warn(ctx, errText)
+			tflog.Warn(ctx, fmt.Sprintf("[WARN] Removing Alert Policy because it's gone %s", name))
 			d.SetId("")
 			return nil
 		} else if x.StatusCode >= 400 {
-			errText := fmt.Sprintf("%d: %s", x.StatusCode, x.Message)
-			tflog.Error(ctx, errText)
+			tflog.Error(ctx, fmt.Sprintf("%d: %s", x.StatusCode, x.Message))
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
I found that attempting to import a team alert policy without specifying the team_id would crash the plugin without providing the user with useful feedback:
```
Stack trace from the terraform-provider-opsgenie_v0.6.34 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x60 pc=0x1034d0e04]

goroutine 30 [running]:
github.com/opsgenie/terraform-provider-opsgenie/opsgenie.resourceOpsGenieAlertPolicyRead({0x1037a2a60?, 0x140001191c0?}, 0x140005c6080, {0x10366d7c0?, 0x140001aaf90?})
	github.com/opsgenie/terraform-provider-opsgenie/opsgenie/resource_opsgenie_alert_policy.go:298 +0x424
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x140003c0a80, {0x1037a2a60, 0x140001191c0}, 0x24?, {0x10366d7c0, 0x140001aaf90})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/schema/resource.go:358 +0xec
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0x140003c0a80, {0x1037a2a60, 0x140001191c0}, 0x140002c4c30, {0x10366d7c0, 0x140001aaf90})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/schema/resource.go:635 +0x30c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0x14000120750, {0x1037a2a60, 0x140001191c0}, 0x14000119240)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/schema/grpc_provider.go:576 +0x3d8
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0x1400011f180, {0x1037a2b08?, 0x140002b1500?}, 0x1400010cc60)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/tf5server/server.go:553 +0x310
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x10376dc40?, 0x1400011f180}, {0x1037a2b08, 0x140002b1500}, 0x1400010cc00, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.5.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x174
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400013c700, {0x1037a6910, 0x14000476000}, 0x140005ba200, 0x140003f6630, 0x103c29c70, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0xaf0
google.golang.org/grpc.(*Server).handleStream(0x1400013c700, {0x1037a6910, 0x14000476000}, 0x140005ba200, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0x840
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.32.0/server.go:859 +0x88
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x298

Error: The terraform-provider-opsgenie_v0.6.34 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```
 We were handling 404's specifically, but ignoring other error types. I've added error handling for other error types and confirms it fixed my particular crash:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Cannot import non-existent remote object
│
│ While attempting to import an existing object to "opsgenie_alert_policy.justinTest", the provider detected that no object
│ exists with the given id. Only pre-existing objects can be imported; check that the id is correct and that it is associated
│ with the provider's configured region or endpoint, or use "terraform apply" to create a new remote object for this resource.
```
I believe this will also resolve [this issue](https://github.com/opsgenie/terraform-provider-opsgenie/issues/360).

As an aside, I introduced the pattern of using the `tflog` package for logging, instead of the `log` package. [Terraform now recommends](https://developer.hashicorp.com/terraform/plugin/log/writing) this pattern for logging, and it solves [the issue I raised here](https://github.com/opsgenie/terraform-provider-opsgenie/issues/419), where filtering logs by level does not work correctly.