### PR TITLE
Fix opsgenie_team_routing_rule documentation 'expected_value' variable

### DIFF
--- a/website/docs/r/team_routing_rule.html.markdown
+++ b/website/docs/r/team_routing_rule.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 * `operation` - (true) It is the operation that will be executed for the given field and key. Possible operations are `matches`, `contains`, `starts-with`, `ends-with`, `equals`, `contains-key`, `contains-value`, `greater-than`, `less-than`, `is-empty` and `equals-ignore-whitespace`.
 
-* `expectedValue` - (Optional) User defined value that will be compared with alert field according to the operation. Default: empty string.
+* `expected_value` - (Optional) User defined value that will be compared with alert field according to the operation. Default: empty string.
 
 * `order` - (Optional) Order of the condition in conditions list.
 


### PR DESCRIPTION
The variable name that Terraform expects and accepts is called 'expected_value'. See also: https://github.com/opsgenie/terraform-provider-opsgenie/blob/master/opsgenie/resource_opsgenie_team_routing_rule.go#L112