### PR TITLE
Issue#437 - Fix team_id update issue

### DIFF
--- a/opsgenie/resource_opsgenie_service.go
+++ b/opsgenie/resource_opsgenie_service.go
@@ -101,27 +101,31 @@ func resourceOpsGenieServiceRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceOpsGenieServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := service.NewClient(meta.(*OpsgenieClient).client.Config)
-	if err != nil {
-		return err
-	}
-	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	tags := flattenTags(d, "tags")
+	 
+	resourceOpsGenieServiceDelete(d, meta)
+	resourceOpsGenieServiceCreate(d, meta)
+	
+	// client, err := service.NewClient(meta.(*OpsgenieClient).client.Config)
+	// if err != nil {
+	// 	return err
+	// }
+	// name := d.Get("name").(string)
+	// description := d.Get("description").(string)
+	// tags := flattenTags(d, "tags")
 
-	log.Printf("[INFO] Updating OpsGenie service '%s'", name)
+	// log.Printf("[INFO] Updating OpsGenie service '%s'", name)
 
-	updateRequest := &service.UpdateRequest{
-		Id:          d.Id(),
-		Name:        name,
-		Description: description,
-		Tags:        tags,
-	}
+	// updateRequest := &service.UpdateRequest{
+	// 	Id:          d.Id(),
+	// 	Name:        name,
+	// 	Description: description,
+	// 	Tags:        tags,
+	// }
 
-	_, err = client.Update(context.Background(), updateRequest)
-	if err != nil {
-		return err
-	}
+	// _, err = client.Update(context.Background(), updateRequest)
+	// if err != nil {
+	// 	return err
+	// }
 
 	return nil
 }


### PR DESCRIPTION
Issue#437 - Fix team_id update issue

Issue raised - https://github.com/opsgenie/terraform-provider-opsgenie/issues/437
Support ticket raised - https://support.atlassian.com/requests/PCS-181010/

Problem statement:
When we try to update "Owner team" i.e; team_id via opsgenie_service resource then team_id (Owner team) is not updated. Service name, description, tags are updated correctly during update, but team_id fails to get updated.
Same happens when we try to update the team manually. i.e when we remove a team manually from a service via UI and immediately add another service, then the service doesn't gets updated. To update the new "Owner team" manually we need to wait for some time after removing the previous Owner and then attach the new Owner.

Quick fix:
Adding delete & creation on service in the update, to delete & create the required service back, as team_id update is not possible as explained in the problem statement.
