### PR TITLE
docs: add username detail to team page

### DIFF
--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -67,6 +67,7 @@ The following arguments are supported:
 
 * `id` - (Required) The UUID for the member to add to this Team.
 * `role` - (Optional) The role for the user within the Team - can be either `admin` or `user`. Default: `user`.
+* `username` - (Optional) The username of the member to add to this Team. **Failure to add this will result in the membership being destroyed and recreated in every plan, making the plan very noisy.**
 
 ## Attributes Reference
 


### PR DESCRIPTION
When adding members to a team, if you don't specify the username in the `member` block, the member is deleted and recreated with every plan. A workaround for this is to set the `username` for the member as well.

https://github.com/opsgenie/terraform-provider-opsgenie/issues/418